### PR TITLE
refactor: drop defer() + Suspense for eager await + json() under v3_singleFetch

### DIFF
--- a/app/pages/CollectionDetailsPage.tsx
+++ b/app/pages/CollectionDetailsPage.tsx
@@ -1,27 +1,24 @@
 import {
-  Await,
   Link,
   useLoaderData,
   useNavigation,
-  useAsyncValue,
 } from "@remix-run/react";
 import type { CollectionDetailsLoader } from "~/routes/collections.$collectionId";
 import { PageContainer, ImageCard } from "~/components";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { User, Loader2 } from "lucide-react";
 import { convertUtcDateToLocalDateString } from "~/client";
-import { Skeleton } from "@/components/ui/skeleton";
-import React from "react";
 import type { ImageDetail } from "~/server/getImage";
 
-type ResolvedCollection = Awaited<CollectionDetailsLoader["collection"]>;
+type ResolvedCollection = NonNullable<CollectionDetailsLoader["collection"]>;
 
 const CollectionDetailsAccessor = ({
   isNavigating,
+  resolvedCollection,
 }: {
   isNavigating: boolean;
+  resolvedCollection: ResolvedCollection;
 }) => {
-  const resolvedCollection = useAsyncValue() as ResolvedCollection;
 
   return (
     <div className="relative w-full max-w-7xl mx-auto px-4 md:px-8 lg:px-12">
@@ -114,54 +111,27 @@ const CollectionDetailsAccessor = ({
   );
 };
 
-const CollectionDetailsSkeleton = () => {
-  return (
-    <div className="w-full max-w-7xl mx-auto px-4 md:px-8 lg:px-12">
-      <div className="py-8 border-b border-zinc-200 dark:border-zinc-800">
-        <div className="flex flex-col gap-4">
-          <Skeleton className="h-8 w-64 bg-gray-700/50" />
-          <Skeleton className="h-4 w-96 bg-gray-700/50" />
-        </div>
-
-        <div className="flex items-center gap-4 mt-6">
-          <Skeleton className="h-8 w-8 rounded-full bg-gray-700/50" />
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-32 bg-gray-700/50" />
-            <Skeleton className="h-3 w-48 bg-gray-700/50" />
-          </div>
-        </div>
-      </div>
-
-      <div className="py-8">
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <Skeleton key={i} className="aspect-square w-full bg-gray-700/50" />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-};
-
 export default function CollectionDetailsPage() {
   const { collection } = useLoaderData<CollectionDetailsLoader>();
   const navigation = useNavigation();
   const isNavigating = navigation.state !== "idle";
 
+  if (!collection) {
+    return (
+      <PageContainer>
+        <div className="p-4">
+          <p className="text-red-500">Error loading collection details</p>
+        </div>
+      </PageContainer>
+    );
+  }
+
   return (
     <PageContainer>
-      <React.Suspense fallback={<CollectionDetailsSkeleton />}>
-        <Await
-          resolve={collection}
-          errorElement={
-            <div className="p-4">
-              <p className="text-red-500">Error loading collection details</p>
-            </div>
-          }
-        >
-          <CollectionDetailsAccessor isNavigating={isNavigating} />
-        </Await>
-      </React.Suspense>
+      <CollectionDetailsAccessor
+        isNavigating={isNavigating}
+        resolvedCollection={collection}
+      />
     </PageContainer>
   );
 }

--- a/app/pages/ExploreImageDetailsPage.tsx
+++ b/app/pages/ExploreImageDetailsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useLoggedInUser } from "~/hooks";
-import { Await, Link, useAsyncValue, useLoaderData, useNavigate } from "@remix-run/react";
+import { Link, useLoaderData, useNavigate } from "@remix-run/react";
 import type { ExplorePageImageLoader } from "~/routes/explore.$imageId";
 import { convertUtcDateToLocalDateString } from "~/client";
 import {
@@ -14,7 +14,6 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   MessageCircle,
   Info,
-  Loader2,
   X,
   Cpu,
   Images,
@@ -106,15 +105,13 @@ interface ExploreImageDetailsPageProps {
 //   );
 // };
 
-export type AsyncImageData = Awaited<
-  Awaited<ReturnType<ExplorePageImageLoader>>["data"]
->;
+export type AsyncImageData = Awaited<ReturnType<ExplorePageImageLoader>>["data"];
 export type ImageUserData = NonNullable<AsyncImageData["user"]>;
 
 const ExploreImageDetailsPageAccessor = ({
   onClose,
-}: ExploreImageDetailsPageProps) => {
-  const imageData = useAsyncValue() as AsyncImageData;
+  imageData,
+}: ExploreImageDetailsPageProps & { imageData: AsyncImageData }) => {
   const imageUserData = imageData.user as ImageUserData;
   const userData = useLoggedInUser();
   const navigate = useNavigate();
@@ -695,6 +692,7 @@ const ExploreImageDetailsPageAccessor = ({
 
 const ExploreImageDetailsPage = ({ onClose }: ExploreImageDetailsPageProps) => {
   const loaderData = useLoaderData<ExplorePageImageLoader>();
+  const imageData = loaderData.data as AsyncImageData;
   const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
@@ -709,73 +707,29 @@ const ExploreImageDetailsPage = ({ onClose }: ExploreImageDetailsPageProps) => {
 
   if (isMobile) {
     return (
-      <React.Suspense
-        fallback={
-          <div className="fixed inset-0 z-[100] flex items-center justify-center">
-            <Loader2 className="h-12 w-12 animate-spin text-zinc-500" />
-          </div>
-        }
-      >
-        <Await
-          resolve={loaderData.data}
-          errorElement={
-            <div className="p-4">
-              <p className="text-red-500">Error loading image details</p>
-            </div>
-          }
-        >
-          <div className="min-h-screen z-[500] relative dark:bg-zinc-900">
-            <ExploreImageDetailsPageAccessor onClose={onClose} />
-          </div>
-        </Await>
-      </React.Suspense>
+      <div className="min-h-screen z-[500] relative dark:bg-zinc-900">
+        <ExploreImageDetailsPageAccessor onClose={onClose} imageData={imageData} />
+      </div>
     );
   }
 
   return (
     <>
       <div className="fixed inset-0 bg-black/80 z-[99]" />
-      <React.Suspense
-        fallback={
-          <div className="fixed inset-0 z-[100] flex items-center justify-center">
-            <Loader2 className="h-12 w-12 animate-spin text-zinc-500" />
-          </div>
-        }
-      >
-        <Await
-          resolve={loaderData.data}
-          errorElement={
-            <Dialog open={true} onOpenChange={onClose}>
-              <DialogContent>
-                <VisuallyHidden asChild>
-                  <DialogTitle>Error</DialogTitle>
-                </VisuallyHidden>
-                <VisuallyHidden asChild>
-                  <DialogDescription>Error loading image details</DialogDescription>
-                </VisuallyHidden>
-                <div className="p-4">
-                  <p className="text-red-500">Error loading image details</p>
-                </div>
-              </DialogContent>
-            </Dialog>
-          }
+      <Dialog open={true} onOpenChange={onClose}>
+        <DialogContent
+          className="w-full md:max-w-[90%] md:h-[90vh] p-0 gap-0 dark:bg-zinc-900 overflow-hidden z-[100] [&>button]:absolute [&>button]:right-4 [&>button]:top-4 [&>button]:z-10 [&>button_span]:hidden"
+          onInteractOutside={(e) => e.preventDefault()}
         >
-          <Dialog open={true} onOpenChange={onClose}>
-            <DialogContent
-              className="w-full md:max-w-[90%] md:h-[90vh] p-0 gap-0 dark:bg-zinc-900 overflow-hidden z-[100] [&>button]:absolute [&>button]:right-4 [&>button]:top-4 [&>button]:z-10 [&>button_span]:hidden"
-              onInteractOutside={(e) => e.preventDefault()}
-            >
-              <VisuallyHidden asChild>
-                <DialogTitle>Image Details</DialogTitle>
-              </VisuallyHidden>
-              <VisuallyHidden asChild>
-                <DialogDescription>View and interact with image details, comments, and generation parameters</DialogDescription>
-              </VisuallyHidden>
-              <ExploreImageDetailsPageAccessor onClose={onClose} />
-            </DialogContent>
-          </Dialog>
-        </Await>
-      </React.Suspense>
+          <VisuallyHidden asChild>
+            <DialogTitle>Image Details</DialogTitle>
+          </VisuallyHidden>
+          <VisuallyHidden asChild>
+            <DialogDescription>View and interact with image details, comments, and generation parameters</DialogDescription>
+          </VisuallyHidden>
+          <ExploreImageDetailsPageAccessor onClose={onClose} imageData={imageData} />
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/app/pages/UserCollectionsPage.tsx
+++ b/app/pages/UserCollectionsPage.tsx
@@ -1,4 +1,4 @@
-import { Await, useLoaderData, useNavigation } from "@remix-run/react";
+import { useLoaderData, useNavigation } from "@remix-run/react";
 import type { GetUserCollectionsResponse } from "~/server/getUserCollections";
 import { PageContainer } from "~/components";
 import { Card, CardContent } from "@/components/ui/card";
@@ -11,28 +11,11 @@ import {
 } from "@/components/ui/table";
 import { CreateCollectionDialog } from "~/components/CreateCollectionDialog";
 import { CollectionRow } from "~/components/CollectionRow";
-import { Skeleton } from "@/components/ui/skeleton";
-import React from "react";
 import { Loader2 } from "lucide-react";
-
-const CollectionsTableSkeleton = () => {
-  return (
-    <div className="space-y-4">
-      {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="flex items-center gap-4 p-4">
-          <Skeleton className="h-6 w-48 bg-gray-700/50" />
-          <Skeleton className="h-6 flex-1 bg-gray-700/50" />
-          <Skeleton className="h-6 w-16 bg-gray-700/50" />
-          <Skeleton className="h-8 w-20 bg-gray-700/50" />
-        </div>
-      ))}
-    </div>
-  );
-};
 
 const UserCollectionsPage = () => {
   const { data } = useLoaderData<{
-    data: Promise<GetUserCollectionsResponse>;
+    data: GetUserCollectionsResponse;
   }>();
 
   const navigation = useNavigation();
@@ -48,52 +31,31 @@ const UserCollectionsPage = () => {
         <Card className="mb-6">
           <CardContent className="p-0">
             <div className="relative min-h-[400px]">
-              <React.Suspense fallback={<CollectionsTableSkeleton />}>
-                <Await
-                  resolve={data as Promise<GetUserCollectionsResponse>}
-                  errorElement={
-                    <div className="p-4 text-red-500">
-                      Error loading collections
-                    </div>
-                  }
-                >
-                  {(resolvedData) => {
-                    return (
-                      <>
-                        {isNavigating && (
-                          <div className="absolute inset-0 bg-background/50 backdrop-blur-sm flex items-center justify-center z-50">
-                            <div className="flex items-center gap-2 text-muted-foreground">
-                              <Loader2 className="h-8 w-8 animate-spin" />
-                            </div>
-                          </div>
-                        )}
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>Title</TableHead>
-                              <TableHead>Description</TableHead>
-                              <TableHead className="text-right">
-                                Images
-                              </TableHead>
-                              <TableHead className="w-[100px]">
-                                Actions
-                              </TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {resolvedData.collections.map((collection) => (
-                              <CollectionRow
-                                key={collection.id}
-                                collection={collection}
-                              />
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </>
-                    );
-                  }}
-                </Await>
-              </React.Suspense>
+              {isNavigating && (
+                <div className="absolute inset-0 bg-background/50 backdrop-blur-sm flex items-center justify-center z-50">
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-8 w-8 animate-spin" />
+                  </div>
+                </div>
+              )}
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead className="text-right">Images</TableHead>
+                    <TableHead className="w-[100px]">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.collections.map((collection) => (
+                    <CollectionRow
+                      key={collection.id}
+                      collection={collection}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           </CardContent>
         </Card>

--- a/app/routes/collections.$collectionId.tsx
+++ b/app/routes/collections.$collectionId.tsx
@@ -1,6 +1,6 @@
 import {
   type LoaderFunctionArgs,
-  defer,
+  json,
   type SerializeFrom,
   MetaFunction,
 } from "@remix-run/node";
@@ -10,14 +10,12 @@ import CollectionDetailsPage from "~/pages/CollectionDetailsPage";
 import { getS3BucketThumbnailURL, getS3BucketURL } from "~/utils/s3Utils";
 import { Link } from "@remix-run/react";
 
-export const meta: MetaFunction<typeof loader> = () => {
-  // Note: With defer, collection is a Promise that hasn't resolved yet
-  // so we use a generic title that will be updated by the page
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
   return [
-    { title: "Collection | AI Image Gallery" },
+    { title: data?.collection.title ? `${data.collection.title} | Pixel Studio` : "Collection | Pixel Studio" },
     {
       name: "description",
-      content: "View images in this collection",
+      content: data?.collection.description || "View images in this collection",
     },
   ];
 };
@@ -26,8 +24,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const collectionId = params.collectionId;
   invariantResponse(collectionId, "Collection ID is required");
 
-  // We wrap the database query in a Promise to use with defer
-  const collectionPromise = prisma.collection
+  const collection = await prisma.collection
     .findUnique({
       where: { id: collectionId },
       select: {
@@ -96,8 +93,8 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
       };
     });
 
-  return defer({
-    collection: collectionPromise,
+  return json({
+    collection,
   });
 };
 

--- a/app/routes/collections._index.tsx
+++ b/app/routes/collections._index.tsx
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, defer } from "@remix-run/node";
+import { type LoaderFunctionArgs, json } from "@remix-run/node";
 import { requireUserLogin } from "~/services";
 import { getUserCollections } from "~/server/getUserCollections";
 import UserCollectionsPage from "~/pages/UserCollectionsPage";
@@ -6,14 +6,13 @@ import UserCollectionsPage from "~/pages/UserCollectionsPage";
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await requireUserLogin(request);
 
-  // Wrap the data fetching in a promise for defer
-  const collectionsPromise = getUserCollections(user.id).then((data) => ({
-    collections: data.collections,
-    count: data.count,
-  }));
+  const data = await getUserCollections(user.id);
 
-  return defer({
-    data: collectionsPromise,
+  return json({
+    data: {
+      collections: data.collections,
+      count: data.count,
+    },
   });
 };
 

--- a/app/routes/feed._index.tsx
+++ b/app/routes/feed._index.tsx
@@ -1,8 +1,6 @@
 import React, { memo, useCallback, useMemo } from "react";
-import { defer, type LoaderFunctionArgs } from "@remix-run/node";
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
 import {
-  Await,
-  useAsyncValue,
   useLoaderData,
   useNavigation,
   Link,
@@ -10,8 +8,6 @@ import {
 import {
   PageContainer,
   GeneralErrorBoundary,
-  ErrorList,
-  ImageGridSkeleton,
 } from "~/components";
 import { fallbackImageSource } from "~/client";
 import { requireUserLogin } from "~/services/auth.server";
@@ -42,24 +38,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const pageSize = Number(searchParams.get("page_size")) || 20;
 
   const cacheKey = `following-feed:${user.id}:${currentPage}:${pageSize}`;
-  const feedData = getCachedDataWithRevalidate(
+  const feedData = await getCachedDataWithRevalidate(
     cacheKey,
     () => getFollowingFeed(user.id, currentPage, pageSize),
     FEED_CACHE_TTL
   );
 
-  return defer({ feedData, currentPage });
+  return json({ feedData, currentPage });
 }
 
 export type FeedLoaderData = typeof loader;
-
-const LoadingSkeleton = () => {
-  return (
-    <div className="w-full space-y-6 animate-pulse">
-      <ImageGridSkeleton />
-    </div>
-  );
-};
 
 const FeedImageCard = memo(function FeedImageCard({
   imageData,
@@ -235,9 +223,8 @@ const EmptyFeed = () => {
   );
 };
 
-const FeedAccessor = () => {
-  const asyncData = useAsyncValue() as FeedData;
-  const items = asyncData.items;
+const FeedAccessor = ({ feedData }: { feedData: FeedData }) => {
+  const items = feedData.items;
 
   const [selectedItem, setSelectedItem] = React.useState<FeedItem | null>(null);
 
@@ -330,7 +317,7 @@ const FeedAccessor = () => {
 };
 
 export default function FeedPage() {
-  const loaderData = useLoaderData<typeof loader>();
+  const { feedData } = useLoaderData<typeof loader>();
   const navigation = useNavigation();
   const isLoading = navigation.state !== "idle";
 
@@ -352,35 +339,26 @@ export default function FeedPage() {
             />
           }
         />
-        <React.Suspense fallback={<LoadingSkeleton />}>
-          <Await
-            resolve={loaderData.feedData}
-            errorElement={
-              <ErrorList errors={["There was an error loading your feed"]} />
-            }
-          >
-            <div className="relative">
-              {isLoading ? (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-bg/50 backdrop-blur-sm">
-                  <Loader2 className="h-8 w-8 animate-spin text-fg-muted" />
-                </div>
-              ) : (
-                <FeedAccessor />
-              )}
+        <div className="relative">
+          {isLoading ? (
+            <div className="absolute inset-0 z-50 flex items-center justify-center bg-bg/50 backdrop-blur-sm">
+              <Loader2 className="h-8 w-8 animate-spin text-fg-muted" />
             </div>
-            <div className="mt-12 flex flex-col items-center gap-2 border-t border-[var(--border)] py-10 text-center">
-              <span className="grid h-10 w-10 place-items-center rounded-full bg-success-soft text-success">
-                <Check className="h-5 w-5" strokeWidth={2.4} />
-              </span>
-              <p className="text-[15px] font-semibold text-fg">
-                You&apos;re all caught up
-              </p>
-              <Link to="/explore" prefetch="intent" className="text-[13px] font-semibold text-[var(--accent-text)] hover:underline">
-                Discover more creations
-              </Link>
-            </div>
-          </Await>
-        </React.Suspense>
+          ) : (
+            <FeedAccessor feedData={feedData as unknown as FeedData} />
+          )}
+        </div>
+        <div className="mt-12 flex flex-col items-center gap-2 border-t border-[var(--border)] py-10 text-center">
+          <span className="grid h-10 w-10 place-items-center rounded-full bg-success-soft text-success">
+            <Check className="h-5 w-5" strokeWidth={2.4} />
+          </span>
+          <p className="text-[15px] font-semibold text-fg">
+            You&apos;re all caught up
+          </p>
+          <Link to="/explore" prefetch="intent" className="text-[13px] font-semibold text-[var(--accent-text)] hover:underline">
+            Discover more creations
+          </Link>
+        </div>
       </div>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
Audit + convert the remaining `defer()` + `<Await>` + `<Suspense>` patterns in the app. The Remix `v3_singleFetch` future flag (enabled in `vite.config.ts`) turns composed `defer()` + `<Await>` into a Suspense stall — the loader's Promise never settles on the client. ExplorePage and UserProfilePage already converted as part of PR #150; this PR converts the four remaining surfaces using the same eager `await` + `json()` pattern.

Tracks the **"Audit remaining `defer()` + `<Await>` patterns"** item in [`REDESIGN_FOLLOWUPS.md`](https://github.com/kevinreber/pixel-studio/blob/main/REDESIGN_FOLLOWUPS.md).

## What changed

| File | Loader change | Page change |
|---|---|---|
| `app/routes/feed._index.tsx` | `defer({ feedData, currentPage })` → `await getCachedDataWithRevalidate(...)` + `json(...)` | Drop `<Suspense>` + `<Await>`; `FeedAccessor` takes `feedData` as a prop |
| `app/routes/collections._index.tsx` + `app/pages/UserCollectionsPage.tsx` | `defer({ data: promise })` → `await getUserCollections(user.id)` + `json(...)` | Drop `<Suspense>` + `<Await>` + `CollectionsTableSkeleton` |
| `app/routes/collections.$collectionId.tsx` + `app/pages/CollectionDetailsPage.tsx` | `defer({ collection: promise })` → `await prisma.collection.findUnique(...)` + `json(...)`; `meta()` upgraded to read the resolved `collection.title` / `description` | Drop `<Suspense>` + `<Await>` + `CollectionDetailsSkeleton`; Accessor receives `resolvedCollection` as a prop |
| `app/pages/ExploreImageDetailsPage.tsx` | (route already eager in main) | Drop `<Suspense>` + `<Await>` + `useAsyncValue` cruft; Accessor receives `imageData` as a prop |

Net: **6 files changed, 104 insertions(+), 244 deletions(-)** — refactor net-removes ~140 lines.

## Behavior
No user-visible change. Pages still:
- Render the same content
- Show a navigation spinner during route transitions via `useNavigation` (where previously wired)
- Handle missing/error states (collection detail's 404 now bubbles via Remix's standard route boundary instead of the `<Await errorElement>`)

## Test plan
- [x] `npm run typecheck` — clean (after one type narrowing on feed `useLoaderData` → `FeedData`)
- [x] `npm run lint` — clean (0 errors)
- [x] `npm run test:run` — 277/277 pass
- [x] `npm run build` — clean
- [ ] Manual smoke (after merge): `/feed`, `/collections`, `/collections/$collectionId`, `/explore/$imageId` modal all render without Suspense stalls
- [ ] CI passes

## Follow-ups still open
The `defer()` + Suspense audit item in `REDESIGN_FOLLOWUPS.md` is now done. Still TODO:
- All prod-monitoring items (smoke-test, Sentry triage, PostHog verification, credit-refund audit, mobile engagement, CodeQL alert)
- Drop the `dall-e-3` layered fallback once gpt-image-1 metrics confirm 100% usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)