### PR TITLE
chore: post-merge housekeeping (followups doc + refund audit script)

### DIFF
--- a/REDESIGN_FOLLOWUPS.md
+++ b/REDESIGN_FOLLOWUPS.md
@@ -4,73 +4,65 @@ Tracking the work that should happen after PR #150 (`feat: redesign Pixel Studio
 
 PR: https://github.com/kevinreber/pixel-studio/pull/150
 
+## Status
+
+| PR | Title | Status |
+|---|---|---|
+| [#150](https://github.com/kevinreber/pixel-studio/pull/150) | feat: redesign Pixel Studio | ✅ merged |
+| [#151](https://github.com/kevinreber/pixel-studio/pull/151) | chore: post-redesign cleanup (curated) | ✅ merged |
+| [#152](https://github.com/kevinreber/pixel-studio/pull/152) | docs: redesign aftermath | ✅ merged |
+| [#153](https://github.com/kevinreber/pixel-studio/pull/153) | refactor: drop defer() + Suspense | ✅ merged |
+
+Everything that could be done from local code is now landed. Remaining items all need prod / external access.
+
 ---
 
-## 1. Same-day after merge
+## 1. Prod smoke + verification (needs deploy access)
 
 - [ ] **Smoke-test prod after deploy**
   - Landing: anchor scroll for `#lp-models` / `#lp-pricing` lands ~72px below the top bar (no jump to "Made by the community").
   - `/create`: generate an image end-to-end. Validates the layered OpenAI fallback (`dall-e-3` → `dall-e-3` w/o params → `gpt-image-1`) on production keys.
   - Theme toggle: flip light↔dark, reload — preference persists (writes to `User.theme` via `api.preferences.theme`).
-  - `/explore`: page renders without spinner stall (validates `defer()` → `await` + `json()` refactor under `v3_singleFetch`).
+  - `/explore`, `/feed`, `/collections`, `/collections/$collectionId`, `/explore/$imageId` modal: render without spinner stall (validates the `defer()` → `await` + `json()` refactor under `v3_singleFetch` — PR #153).
 
 - [ ] **Verify PostHog autocapture is firing in prod**
-  - `app/entry.client.tsx` now defers `initPostHog` past `window.load` to avoid hydration mismatches.
+  - `app/entry.client.tsx` defers `initPostHog` past `window.load` to avoid hydration mismatches.
   - Confirm pageviews + autocapture events are landing in PostHog.
   - Watch browser console + Sentry for any `Hydration failed` warnings.
 
-- [x] ~~**Remove `pr-screenshots/` from the repo**~~ — **Reclassified as intentional.** The 32 PNGs (desktop + iPhone 14 Pro Max before/after) are kept as a permanent visual record of the redesign. See `pr-screenshots/README.md`.
+## 2. First-week monitoring (needs Sentry / PostHog / DB access)
 
-## 2. First-week monitoring
-
-- [ ] **Sentry triage** — watch for new error signatures on `/create`, `/create-video`, `/profile/*`, and admin routes. The `defer()` → `json()` switch changed loader return shapes; any client code still expecting a `Promise` will surface here.
+- [ ] **Sentry triage** — watch for new error signatures on `/create`, `/create-video`, `/profile/*`, `/feed`, `/collections`, and admin routes. The `defer()` → `json()` switches in PRs #150 and #153 changed loader return shapes; any client code still expecting a `Promise` will surface here.
 
 - [ ] **Admin staleness check** — all `admin.*` loaders now cache 60s via `getCachedDataWithRevalidate`. If credit edits / user bans aren't visible within ~60s, that's expected. If it actively confuses you, drop TTL to 15s in those loaders.
 
-- [ ] **Credit-refund audit** — `app/services/qstash.server.ts` flipped `refundCredits: false → true`. Query `CreditTransaction` for recent rows of `type=refund` and confirm:
-  - Refunds appear when a generation legitimately fails.
-  - Refunds do **not** double-fire (one failed job should produce exactly one refund row).
+- [ ] **Credit-refund audit** — `app/services/qstash.server.ts` flipped `refundCredits: false → true`. **Pre-written script:** `scripts/auditCreditRefunds.ts`. Run with `npx tsx scripts/auditCreditRefunds.ts` against prod `DATABASE_URL`. Confirms:
+  - Refunds appear when generations legitimately fail
+  - Refunds do **not** double-fire (one failed job → exactly one refund row)
+  - No orphan refunds (refunds without matching `spend` rows)
 
-- [ ] **Mobile engagement signal** — pull PostHog session recordings on iPhone/Android viewports for the first week. Validate the new bottom-tab nav + FAB are getting tapped, and check for stuck-viewport edge cases (e.g. the bottom-sheet on `/create`).
+- [ ] **Mobile engagement signal** — pull PostHog session recordings on iPhone/Android viewports. Validate the bottom-tab nav + FAB are getting tapped, and watch for stuck-viewport edge cases (e.g. the bottom-sheet on `/create`).
 
-## 3. Tech-debt cleanup (next sprint)
+## 3. Tech-debt cleanup (waiting on metrics / external scans)
 
 - [ ] **Drop the layered `dall-e-3` fallback** in `app/server/createNewDallEImages.ts`
   - Currently: try `dall-e-3` w/ `style`+`quality` → retry w/o those params → fall back to `gpt-image-1` (with `mapSizeToGptImage1()`).
   - Only the last layer is succeeding in prod (OpenAI deprecated all of `response_format`, then `style`/`quality`, then `dall-e-3` itself in sequence).
   - Once metrics confirm 100% of OpenAI traffic hits the `gpt-image-1` branch, delete the first two layers and rename the function.
 
-- [ ] **Audit remaining `defer()` + `<Await>` patterns under `v3_singleFetch`**
-  - The flag is enabled in `vite.config.ts`. `ExplorePage` and `UserProfilePage` had Suspense stalls because of it.
-  - Run `grep -rn "defer(" app/routes app/pages` and `grep -rn "<Await" app/routes app/pages`. Any composed `Promise.all` inside a `defer()` is a probable stall.
-
-- [x] ~~**Remove `design_handoff_pixel_studio_redesign/` from the working tree**~~ — **Partially closed.** PR #151 curated the bundle: kept `README.md` (design brief), `redesign/tokens.css` (source-of-truth tokens), and `screenshots/{desktop,mobile}/*.png` (intended-state mockups) as a historical record. Removed the standalone HTML previews, prototype JSX shells, and ~30 decorative placeholder JPGs (all process-only scaffolding).
-
 - [ ] **Verify CodeQL `js/xss-through-dom` alert stays dismissed**
   - `app/components/ImagePicker.tsx` validates URLs via `isSafeImageUrl()` before assigning to `<img src>`. Alert was dismissed as a false positive with that justification.
   - On the next weekly CodeQL run, confirm it does not reappear.
 
-- [ ] **Trim `.eslintrc.cjs` ignorePatterns**
-  - Currently includes `design_handoff/`, `playwright-report/`, `tmp-screenshots/`.
-  - Remove `design_handoff/` and `tmp-screenshots/` once those directories are gone.
+## Closed (no further action)
 
-## 4. Docs / coordination
-
-- [ ] **Update `CHANGELOG.md`** with:
-  - "Full app redesign — tokens, primitives, shell, all core screens."
-  - "OpenAI provider switched from `dall-e-3` to `gpt-image-1` (with fallback chain)."
-  - "Credit refunds now correctly issued on failed generations."
-
-- [ ] **Tidy `app/.claude/CLAUDE.md`**
-  - Note that `dall-e-2` model is removed from `app/config/models.ts`.
-  - Note that DALL-E 3 falls back to `gpt-image-1` under the hood.
-  - Re-check whether the "Supabase v2 auth migration in progress" line still applies.
-
-- [ ] **Publish a What's New post**
-  - The `/whats-new` page (`app/routes/whats-new.tsx`) is the natural place for users to discover:
-    - The redesign itself.
-    - Theme toggle (light + dark).
-    - New mobile bottom-tab nav + FAB.
+- [x] ~~**Remove `pr-screenshots/` from the repo**~~ — PR #151. **Reclassified as intentional historical record.** Kept the 32 PNGs (desktop + iPhone 14 Pro Max before/after) with `pr-screenshots/README.md` documenting them.
+- [x] ~~**Audit remaining `defer()` + `<Await>` patterns under `v3_singleFetch`**~~ — PR #153. Converted feed, collections list, collection detail, and explore image-detail page. Net −140 lines.
+- [x] ~~**Remove `design_handoff_pixel_studio_redesign/` from the working tree**~~ — PR #151. **Curated:** kept the README brief, `tokens.css`, `screenshots/{desktop,mobile}/`, and the prototype's art tiles. Removed the standalone HTML previews and prototype JSX shells.
+- [x] ~~**Trim `.eslintrc.cjs` ignorePatterns**~~ — PR #151. Dropped `design_handoff/` and `tmp-screenshots/` entries; kept `playwright-report/`.
+- [x] ~~**Update `CHANGELOG.md`**~~ — PR #152. Added entries for the redesign system, OpenAI provider switch, credit refund fix, PostHog hydration fix, and defer()→json() Suspense-stall fix.
+- [x] ~~**Tidy `.claude/CLAUDE.md`**~~ — PR #152. Updated Tech Stack + Image Providers rows to reflect `gpt-image-1`; added redesign + provider-switch entries to Recent Features.
+- [x] ~~**Publish a What's New post**~~ — PR #152. New entry at top of `app/config/buildLogs.ts` ("Fresh look — full app redesign", 2026-06-06, `category=announcement`).
 
 ---
 
@@ -79,3 +71,4 @@ PR: https://github.com/kevinreber/pixel-studio/pull/150
 - The dev-server `connection_limit=1` in `DATABASE_URL` causes serial Prisma queries — admin tabs felt slow until we layered Redis caching on top. Don't "fix" the slow admin by removing the cache; the underlying constraint is the local Postgres connection pool.
 - The PostHog hydration fix is timing-sensitive — if you ever move PostHog init back to module-top-level, the hydration errors return. Keep the `window.load` + `setTimeout(0)` deferral.
 - Anchor links on the landing page need manual `onClick` scrollTo (with 72px offset for the sticky nav). Remix `ScrollRestoration` intercepts plain `<a href="#...">`, which is why pure-anchor links jumped to the wrong section before.
+- The `dall-e-3` layered fallback only the last layer succeeds in prod. Don't waste time debugging the first two — they're there as defensive history. Just count gpt-image-1 hits and remove the dead branches when confident.

--- a/scripts/auditCreditRefunds.ts
+++ b/scripts/auditCreditRefunds.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+
+/**
+ * Credit-refund audit
+ * --------------------
+ * Runs against the production database to verify the fix in PR #150
+ * (qstash.server.ts flipped `refundCredits: false → true`) is behaving
+ * correctly: failed generations should produce exactly one `CreditTransaction`
+ * of `type=refund`, never zero and never two.
+ *
+ * What this reports:
+ *   1. Volume — refund rows over the last 7d and 30d
+ *   2. Double-fires — same userId + same generationLogId producing >1 refund
+ *   3. Orphans — refund rows with no preceding `spend` row referencing the
+ *      same generation (suggests a refund without a charge)
+ *   4. Mean / median refund amount, distribution by day
+ *
+ * Run:
+ *   DATABASE_URL=... npx tsx scripts/auditCreditRefunds.ts
+ *
+ * Tracks: REDESIGN_FOLLOWUPS.md → "Credit-refund audit"
+ */
+
+import "dotenv/config";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const DAY = 24 * 60 * 60 * 1000;
+
+async function main() {
+  const now = Date.now();
+  const since7d = new Date(now - 7 * DAY);
+  const since30d = new Date(now - 30 * DAY);
+
+  console.log("=== Credit refund audit ===");
+  console.log(`Now: ${new Date(now).toISOString()}`);
+  console.log("");
+
+  // ---------- 1. Volume ----------
+  const [count7d, count30d] = await Promise.all([
+    prisma.creditTransaction.count({
+      where: { type: "refund", createdAt: { gte: since7d } },
+    }),
+    prisma.creditTransaction.count({
+      where: { type: "refund", createdAt: { gte: since30d } },
+    }),
+  ]);
+
+  console.log(`Volume:`);
+  console.log(`  Refund rows in last 7d:  ${count7d}`);
+  console.log(`  Refund rows in last 30d: ${count30d}`);
+  console.log("");
+
+  if (count30d === 0) {
+    console.log("No refunds in the last 30d. Either:");
+    console.log("  (a) No generations failed (good)");
+    console.log("  (b) The refund path isn't firing (bad — the bug is back)");
+    console.log("");
+    console.log("Cross-check: count failed generations in the same window.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  // ---------- 2. Double-fires ----------
+  // A double-fire = same userId + same generationLogId produced >1 refund.
+  const refundRows30d = await prisma.creditTransaction.findMany({
+    where: { type: "refund", createdAt: { gte: since30d } },
+    select: { id: true, userId: true, generationLogId: true, amount: true, createdAt: true },
+  });
+
+  type RefundRow = (typeof refundRows30d)[number];
+  const byUserGen = new Map<string, RefundRow[]>();
+  for (const r of refundRows30d) {
+    if (!r.generationLogId) continue;
+    const key = `${r.userId}::${r.generationLogId}`;
+    const arr = byUserGen.get(key) ?? [];
+    arr.push(r);
+    byUserGen.set(key, arr);
+  }
+  const doubleFires = [...byUserGen.entries()].filter(([, rows]) => rows.length > 1);
+
+  console.log(`Double-fires (same user + same generation, multiple refunds):`);
+  if (doubleFires.length === 0) {
+    console.log(`  None ✓`);
+  } else {
+    console.log(`  ${doubleFires.length} cases found:`);
+    for (const [key, rows] of doubleFires.slice(0, 10)) {
+      const [userId, genId] = key.split("::");
+      const amounts = rows.map((r) => r.amount).join(", ");
+      const times = rows.map((r) => r.createdAt.toISOString()).join(" / ");
+      console.log(`    user=${userId} gen=${genId}`);
+      console.log(`      amounts=[${amounts}] at ${times}`);
+    }
+    if (doubleFires.length > 10) {
+      console.log(`    … and ${doubleFires.length - 10} more`);
+    }
+  }
+  console.log("");
+
+  // ---------- 3. Orphans ----------
+  // An orphan = refund references a generationLogId that has no
+  // corresponding `spend` row. (A refund should always follow a charge.)
+  const refundsWithGen = refundRows30d.filter((r) => r.generationLogId);
+  let orphans = 0;
+  const orphanSamples: { userId: string; generationLogId: string }[] = [];
+  for (const refund of refundsWithGen) {
+    const spend = await prisma.creditTransaction.findFirst({
+      where: {
+        userId: refund.userId,
+        generationLogId: refund.generationLogId,
+        type: "spend",
+      },
+      select: { id: true },
+    });
+    if (!spend) {
+      orphans += 1;
+      if (orphanSamples.length < 5) {
+        orphanSamples.push({
+          userId: refund.userId,
+          generationLogId: refund.generationLogId!,
+        });
+      }
+    }
+  }
+  console.log(`Orphan refunds (refund with no matching spend):`);
+  if (orphans === 0) {
+    console.log(`  None ✓`);
+  } else {
+    console.log(`  ${orphans} of ${refundsWithGen.length} refunds have no matching spend row`);
+    for (const o of orphanSamples) {
+      console.log(`    user=${o.userId} gen=${o.generationLogId}`);
+    }
+  }
+  console.log("");
+
+  // ---------- 4. Distribution ----------
+  const amounts = refundRows30d.map((r) => Math.abs(r.amount)).sort((a, b) => a - b);
+  const mean = amounts.reduce((s, a) => s + a, 0) / amounts.length;
+  const median = amounts[Math.floor(amounts.length / 2)];
+  console.log(`Refund amounts (last 30d):`);
+  console.log(`  Count:  ${amounts.length}`);
+  console.log(`  Mean:   ${mean.toFixed(2)} credits`);
+  console.log(`  Median: ${median} credits`);
+  console.log(`  Min:    ${amounts[0]} credits`);
+  console.log(`  Max:    ${amounts[amounts.length - 1]} credits`);
+  console.log("");
+
+  // ---------- 5. Per-day counts ----------
+  console.log(`Refunds per day (last 30d):`);
+  const perDay = new Map<string, number>();
+  for (const r of refundRows30d) {
+    const day = r.createdAt.toISOString().slice(0, 10);
+    perDay.set(day, (perDay.get(day) ?? 0) + 1);
+  }
+  const days = [...perDay.entries()].sort();
+  for (const [day, n] of days) {
+    const bar = "▇".repeat(Math.min(n, 40));
+    console.log(`  ${day} ${String(n).padStart(4)} ${bar}`);
+  }
+
+  console.log("");
+  console.log("=== Done ===");
+  console.log("");
+  console.log("What to look for:");
+  console.log("  Double-fires should be 0.   (If >0, the QStash retry is firing refunds twice.)");
+  console.log("  Orphans should be 0.        (If >0, refunds are firing without a corresponding charge.)");
+  console.log("  Volume should be > 0 on days you know generations failed (cross-check Sentry).");
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Two small housekeeping items now that PRs #151 / #152 / #153 are all merged.

### 1. `REDESIGN_FOLLOWUPS.md` reorganized
- Added a status table at the top showing which PRs landed
- Split into three sections: **Prod smoke + verification**, **First-week monitoring**, **Tech-debt cleanup (waiting on metrics)**
- Moved everything closed by PRs #151 / #152 / #153 into a **Closed (no further action)** section with PR links
- Added a fourth "future-me" note about the `dall-e-3` layered fallback

### 2. `scripts/auditCreditRefunds.ts`
Pre-written audit for the credit-refund follow-up item. PR #150 flipped `qstash.server.ts` from `refundCredits: false → true`, and the doc has been asking for a query to verify refunds are firing correctly. Now there's a script.

Reports (against the production DB):
1. **Volume** — refund-row count over the last 7d and 30d
2. **Double-fires** — same `userId` + same `generationLogId` producing >1 refund
3. **Orphans** — refund rows with no matching `spend` row for the same generation
4. **Distribution** — mean / median / min / max refund amounts
5. **Per-day histogram** — refunds per day over 30d

Run:
```bash
DATABASE_URL=<prod_url> npx tsx scripts/auditCreditRefunds.ts
```

Mirrors the conventions used by `scripts/checkKafkaHealth.ts` and `scripts/backfillVideoThumbnails.ts` — instantiates its own `PrismaClient`, uses `dotenv/config`, has a `tsx` shebang.

## Test plan
- [x] `npm run lint` — clean (0 errors)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Manual run against prod (deferred — you have the access)
- [ ] CI passes

## Follow-ups still open
Everything in section 1 (prod smoke), section 2 (Sentry / PostHog / refund audit), and section 3 (drop `dall-e-3` fallback, CodeQL re-scan) of `REDESIGN_FOLLOWUPS.md`. All require prod or external access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)