### PR TITLE
docs: refresh README + core docs for current architecture, add screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,15 @@ npm run video:backfill-thumbnails  # Backfill thumbnails for existing videos
 
 ```mermaid
 graph TD
-    A[Create form] --> B[Remix action]
-    B --> C[QStash publish]
-    C --> D[/api/queue/process-image]
-    D --> E[Provider SDK call]
-    E --> F[S3 upload]
-    F --> G[Postgres update]
-    G --> H[WebSocket broadcast]
-    H --> I[Live UI progress]
-    I --> J[Redirect to results]
+    A["Create form"] --> B["Remix action"]
+    B --> C["QStash publish"]
+    C --> D["/api/queue/process-image"]
+    D --> E["Provider SDK call"]
+    E --> F["S3 upload"]
+    F --> G["Postgres update"]
+    G --> H["WebSocket broadcast"]
+    H --> I["Live UI progress"]
+    I --> J["Redirect to results"]
 ```
 
 ### Project structure


### PR DESCRIPTION
## Summary

- Rewrites the README around the **current** architecture (Remix + QStash + WebSocket + S3 + Postgres). The pre-redesign sections that described the pre-Kafka/pre-redesign world have been removed.
- Adds 12 product screenshots (8 desktop + 4 mobile) under `docs/images/screenshots/` so the README leads with a visual tour.
- Aligns the other long-form docs with the same reality:
  - `ARCHITECTURE.md` — reflects QStash-as-default, Kafka-on-hold
  - `TECHNICAL_IMPLEMENTATION_GUIDE.md` — annotated with a status banner pointing readers to the current source-of-truth docs
  - `API.md` — endpoints updated to current routes
  - `KAFKA_ENVIRONMENT_SETUP.md` — clarified as the "when you re-enable Kafka" guide
  - `DEVELOPMENT.md` — current dev flow and env requirements
- Fixes the README's Mermaid async-flow diagram, which failed to render on GitHub. The `/api/queue/process-image` node label triggered Mermaid's trapezoid-shape parser (`[/.../]`); quoting all node labels sidesteps it.

### Files touched

| File | Change |
|------|--------|
| `README.md` | Major rewrite + Mermaid fix |
| `ARCHITECTURE.md` | Updated to current arch |
| `TECHNICAL_IMPLEMENTATION_GUIDE.md` | Status banner + alignment |
| `API.md` | Endpoint reference refresh |
| `KAFKA_ENVIRONMENT_SETUP.md` | Reframed as opt-in setup |
| `DEVELOPMENT.md` | Current dev setup |
| `docs/images/screenshots/{desktop,mobile}/*.png` | 12 new screenshots |

## Testing Done

- [x] `npm run lint` — clean (docs-only changes, no code)
- [x] All cross-doc relative links resolve (`./ARCHITECTURE.md`, `./CACHING_STRATEGY.md`, `./env.example`, `./infrastructure/kafka/README.md`, etc.)
- [x] All 12 screenshot paths in the README resolve to files under `docs/images/screenshots/`
- [x] All Markdown code fences balanced across the 13 docs (verified pairwise count)
- [x] `CONTRIBUTING.md` TOC anchors match real headings
- [x] Tables across all docs have consistent column counts
- [ ] Reviewer: confirm the Mermaid diagram renders on the PR's README preview tab on GitHub

## Follow-ups (not blocking this PR)

- `README.md:403` links to `./LICENSE`, but no `LICENSE` file is checked in. Either add a standard MIT LICENSE or drop the link.