### PR TITLE
refactor: drop layered DALL-E fallback, route directly to gpt-image-1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -281,7 +281,7 @@ npm run queue:websocket            # Start WebSocket server (alias)
 
 ### Image Providers (8)
 
-- `createNewDallEImages.ts` - OpenAI image generation. Layered fallback: `dall-e-3` w/ params → `dall-e-3` w/o params → `gpt-image-1` (with `mapSizeToGptImage1()`). `dall-e-2` is no longer exposed.
+- `createNewOpenAIImages.ts` - OpenAI image generation. Calls `gpt-image-1` directly (with `mapSizeToGptImage1()` translating legacy DALL-E sizes). The `model` argument is still passed through as `"dall-e-3"` or `"dall-e-2"` for DB / pricing consistency, but the upstream call always targets `gpt-image-1`. `dall-e-2` is not exposed in the picker.
 - `createNewStableDiffusionImages.ts` - Stable Diffusion
 - `createHuggingFaceImages.ts` - Hugging Face models
 - `createBlackForestImages.ts` - Black Forest AI

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -805,7 +805,7 @@ npm run kafka:websocket
 - Supabase v2 auth migration
 - Short URL image sharing (`/p/$imageId`)
 - **Full app redesign** (PR #150, 2026-06): new design tokens (`app/globals.css` + `tailwind.config.ts`), primitive library (`app/components/ps/*`), app shell (`Sidebar` / `TopBar` / `MobileNav` / `AppShell`), light + dark theme toggle persisted to `User.theme`, redesigned versions of every core screen (consumer + admin).
-- **OpenAI provider switch** (PR #150, 2026-06): `dall-e-3` → `gpt-image-1` with layered fallback. See `app/server/createNewDallEImages.ts`.
+- **OpenAI provider switch** (PR #150, 2026-06): `dall-e-3` → `gpt-image-1`. Originally shipped with a layered fallback; the layers were dropped and the file was renamed in a follow-up (PR #157). See `app/server/createNewOpenAIImages.ts`.
 - Dynamic sitemap generation
 - Credit history and generation history settings pages
 - What's new page for feature announcements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dropped the layered DALL-E fallback chain** — every request now calls `gpt-image-1` directly (the only layer succeeding in prod). Both the `"dall-e-3"` and `"dall-e-2"` model aliases now route through `gpt-image-1`; the `model` value is still stored on the `Image` record so historical data and pricing config stay aligned.
 - **Renamed** `app/server/createNewDallEImages.ts` → `app/server/createNewOpenAIImages.ts`. The exported function `createNewDallEImages` is now `createNewOpenAIImages`; `getDallEMockDataResponse` is now `getOpenAIImagesMockResponse`. Internal helper `mapSizeToGptImage1` and `urlToBase64` are lifted to module scope and exported for unit tests.
-- **Added unit tests** at `app/server/createNewOpenAIImages.test.ts` covering size mapping (1024x1024 / 1024x1792 / 1792x1024 / unknown) and URL → base64 fallback (success, non-OK status, fetch error).
+- **Added 21 tests** at `app/server/createNewOpenAIImages.test.ts`:
+  - Unit: `mapSizeToGptImage1` size mapping (6 cases) and `urlToBase64` URL→base64 fallback (5 cases — success, 404, network throw, non-Error rejection, binary payload).
+  - Integration: 10 cases for `createNewOpenAIImages` itself with mocked OpenAI SDK / `~/server` barrel / S3 utils — `n=1`-per-loop for dall-e-3, batched `n` for dall-e-2, DB record preserves original model string, size-mapping reaches the SDK call, `url`-only response falls through `urlToBase64`, billing-limit error rethrows user-facing message, generic error swallow path, post-set-creation error triggers `deleteSet`, `USE_MOCK_DALLE` short-circuit.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### OpenAI image provider simplification
+
+- **Dropped the layered DALL-E fallback chain** — every request now calls `gpt-image-1` directly (the only layer succeeding in prod). Both the `"dall-e-3"` and `"dall-e-2"` model aliases now route through `gpt-image-1`; the `model` value is still stored on the `Image` record so historical data and pricing config stay aligned.
+- **Renamed** `app/server/createNewDallEImages.ts` → `app/server/createNewOpenAIImages.ts`. The exported function `createNewDallEImages` is now `createNewOpenAIImages`; `getDallEMockDataResponse` is now `getOpenAIImagesMockResponse`. Internal helper `mapSizeToGptImage1` and `urlToBase64` are lifted to module scope and exported for unit tests.
+- **Added unit tests** at `app/server/createNewOpenAIImages.test.ts` covering size mapping (1024x1024 / 1024x1792 / 1792x1024 / unknown) and URL → base64 fallback (success, non-OK status, fetch error).
+
 ### Added
 
 #### Full App Redesign (PR #150 — 2026-06)
@@ -74,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Switched primary OpenAI generation from `dall-e-3` to `gpt-image-1`**
   - OpenAI sequentially deprecated `response_format`, then `style`/`quality`, then `dall-e-3` itself
-  - `app/server/createNewDallEImages.ts` now uses a layered fallback chain: `dall-e-3` w/ params → `dall-e-3` w/o params → `gpt-image-1` (with `mapSizeToGptImage1()` for the `1024x1792` → `1024x1536` mapping)
+  - `app/server/createNewDallEImages.ts` (later renamed to `createNewOpenAIImages.ts`) used a layered fallback chain at the time of this release: `dall-e-3` w/ params → `dall-e-3` w/o params → `gpt-image-1` (with `mapSizeToGptImage1()` for the `1024x1792` → `1024x1536` mapping). The fallback layers were dropped in a follow-up — see Unreleased.
   - `dall-e-2` removed from `app/config/models.ts` (option no longer exposed)
   - Display name shows "OpenAI Image" via `MODEL_DISPLAY_NAMES` in `app/components/ModelBadge.tsx`
 

--- a/REDESIGN_FOLLOWUPS.md
+++ b/REDESIGN_FOLLOWUPS.md
@@ -45,14 +45,20 @@ Everything that could be done from local code is now landed. Remaining items all
 
 ## 3. Tech-debt cleanup (waiting on metrics / external scans)
 
-- [ ] **Drop the layered `dall-e-3` fallback** in `app/server/createNewDallEImages.ts`
-  - Currently: try `dall-e-3` w/ `style`+`quality` → retry w/o those params → fall back to `gpt-image-1` (with `mapSizeToGptImage1()`).
-  - Only the last layer is succeeding in prod (OpenAI deprecated all of `response_format`, then `style`/`quality`, then `dall-e-3` itself in sequence).
-  - Once metrics confirm 100% of OpenAI traffic hits the `gpt-image-1` branch, delete the first two layers and rename the function.
+- [~] **Drop the layered `dall-e-3` fallback** in `app/server/createNewDallEImages.ts`
+  - Status: **simplified in worktree `jolly-tinkering-flute`** — both the dall-e-3 and dall-e-2 branches now call `gpt-image-1` directly. `mapSizeToGptImage1` retained; `urlToBase64` retained; `isUnknownParamError` / `isModelMissingError` helpers and `response_format` removed.
+  - Preserved: per-model `n` behavior (dall-e-3 alias still loops one-at-a-time, dall-e-2 still batches) so prod behavior matches what's been running.
+  - Did **not** rename `createNewDallEImages` → would cascade to `app/server/index.ts`, `app/server/createNewImages.ts`, and the two `app/config/models.ts` comments. Park the rename for a follow-up PR.
+  - **Before merging:** confirm via prod metrics / OpenAI dashboard that 100% of recent OpenAI image traffic was hitting the `gpt-image-1` branch. If any dall-e-3 calls still succeed, the simplification regresses them.
 
 - [ ] **Verify CodeQL `js/xss-through-dom` alert stays dismissed**
   - `app/components/ImagePicker.tsx` validates URLs via `isSafeImageUrl()` before assigning to `<img src>`. Alert was dismissed as a false positive with that justification.
   - On the next weekly CodeQL run, confirm it does not reappear.
+
+## 4. Audits completed this session
+
+- [x] **Credit-refund audit script reviewed** — `scripts/auditCreditRefunds.ts` reads cleanly. Three checks: volume (7d/30d counts), double-fires (same userId+generationLogId producing >1 refund), orphans (refunds without a matching `spend` row). Minor inefficiency: orphan check does one `findFirst` per refund row (N+1). Fine for ad-hoc auditing; convert to a single `groupBy` only if it gets slow at higher refund volume.
+- [x] **PostHog init deferral verified** — `app/entry.client.tsx` defers `initPostHog` past `window.load` then `setTimeout(0)` to push past React's hydration commit. Comment block at the call site explains the failure mode (`<script>` injection shifting SSR DOM out from under hydration). No changes needed.
 
 ## Closed (no further action)
 

--- a/REDESIGN_FOLLOWUPS.md
+++ b/REDESIGN_FOLLOWUPS.md
@@ -45,10 +45,11 @@ Everything that could be done from local code is now landed. Remaining items all
 
 ## 3. Tech-debt cleanup (waiting on metrics / external scans)
 
-- [~] **Drop the layered `dall-e-3` fallback** in `app/server/createNewDallEImages.ts`
-  - Status: **simplified in worktree `jolly-tinkering-flute`** — both the dall-e-3 and dall-e-2 branches now call `gpt-image-1` directly. `mapSizeToGptImage1` retained; `urlToBase64` retained; `isUnknownParamError` / `isModelMissingError` helpers and `response_format` removed.
+- [~] **Drop the layered `dall-e-3` fallback** in `app/server/createNewOpenAIImages.ts` (PR #157, worktree `jolly-tinkering-flute`)
+  - Status: **simplified, renamed, and unit-tested** — both the dall-e-3 and dall-e-2 branches now call `gpt-image-1` directly. `isUnknownParamError` / `isModelMissingError` helpers and `response_format` removed; `mapSizeToGptImage1` and `urlToBase64` lifted to module scope and exported for tests.
   - Preserved: per-model `n` behavior (dall-e-3 alias still loops one-at-a-time, dall-e-2 still batches) so prod behavior matches what's been running.
-  - Did **not** rename `createNewDallEImages` → would cascade to `app/server/index.ts`, `app/server/createNewImages.ts`, and the two `app/config/models.ts` comments. Park the rename for a follow-up PR.
+  - Renamed (same PR): file → `createNewOpenAIImages.ts`, function `createNewDallEImages` → `createNewOpenAIImages`, mock helper `getDallEMockDataResponse` → `getOpenAIImagesMockResponse`. Callers in `app/server/index.ts`, `app/server/createNewImages.ts`, and the two `app/config/models.ts` comments updated.
+  - Tests added: `app/server/createNewOpenAIImages.test.ts` covers `mapSizeToGptImage1` (all four cases) and `urlToBase64` (success, 404, fetch error, non-Error rejection, binary payload).
   - **Before merging:** confirm via prod metrics / OpenAI dashboard that 100% of recent OpenAI image traffic was hitting the `gpt-image-1` branch. If any dall-e-3 calls still succeed, the simplification regresses them.
 
 - [ ] **Verify CodeQL `js/xss-through-dom` alert stays dismissed**

--- a/REDESIGN_FOLLOWUPS.md
+++ b/REDESIGN_FOLLOWUPS.md
@@ -46,10 +46,13 @@ Everything that could be done from local code is now landed. Remaining items all
 ## 3. Tech-debt cleanup (waiting on metrics / external scans)
 
 - [~] **Drop the layered `dall-e-3` fallback** in `app/server/createNewOpenAIImages.ts` (PR #157, worktree `jolly-tinkering-flute`)
-  - Status: **simplified, renamed, and unit-tested** — both the dall-e-3 and dall-e-2 branches now call `gpt-image-1` directly. `isUnknownParamError` / `isModelMissingError` helpers and `response_format` removed; `mapSizeToGptImage1` and `urlToBase64` lifted to module scope and exported for tests.
+  - Status: **simplified, renamed, and unit + integration tested** — both the dall-e-3 and dall-e-2 branches now call `gpt-image-1` directly. `isUnknownParamError` / `isModelMissingError` helpers and `response_format` removed; `mapSizeToGptImage1` and `urlToBase64` lifted to module scope and exported for tests.
   - Preserved: per-model `n` behavior (dall-e-3 alias still loops one-at-a-time, dall-e-2 still batches) so prod behavior matches what's been running.
   - Renamed (same PR): file → `createNewOpenAIImages.ts`, function `createNewDallEImages` → `createNewOpenAIImages`, mock helper `getDallEMockDataResponse` → `getOpenAIImagesMockResponse`. Callers in `app/server/index.ts`, `app/server/createNewImages.ts`, and the two `app/config/models.ts` comments updated.
-  - Tests added: `app/server/createNewOpenAIImages.test.ts` covers `mapSizeToGptImage1` (all four cases) and `urlToBase64` (success, 404, fetch error, non-Error rejection, binary payload).
+  - Tests in `app/server/createNewOpenAIImages.test.ts` — **21 cases**:
+    - `mapSizeToGptImage1` (6): all four return branches + empty + garbage input
+    - `urlToBase64` (5): success, 404, network throw, non-Error rejection, binary payload
+    - `createNewOpenAIImages` integration (10): missing userId / dall-e-3 loops with `n=1` / dall-e-2 batches with `n=3` / DB record preserves the original model string / size mapping `1024x1792 → 1024x1536` flows through to the SDK call / `url`-only response falls back through `urlToBase64` / billing-limit error rethrows the user-facing message / generic SDK error swallowed (set never created) / post-set-creation error deletes the set / `USE_MOCK_DALLE` short-circuit
   - **Before merging:** confirm via prod metrics / OpenAI dashboard that 100% of recent OpenAI image traffic was hitting the `gpt-image-1` branch. If any dall-e-3 calls still succeed, the simplification regresses them.
 
 - [ ] **Verify CodeQL `js/xss-through-dom` alert stays dismissed**

--- a/app/config/models.ts
+++ b/app/config/models.ts
@@ -80,7 +80,7 @@ export const MODEL_OPTIONS = [
     // OpenAI deprecated `dall-e-3` and migrated projects to `gpt-image-1`.
     // We keep the internal `value: "dall-e-3"` so existing DB records, pricing
     // config, and generation logs continue to work — the server-side call
-    // transparently routes to gpt-image-1 (see createNewDallEImages.ts).
+    // transparently routes to gpt-image-1 (see createNewOpenAIImages.ts).
     name: "OpenAI Image",
     value: "dall-e-3",
     image: "/assets/model-thumbs/dalle3.jpg",
@@ -91,7 +91,7 @@ export const MODEL_OPTIONS = [
     recommended: true,
   },
   // DALL-E 2 was removed from the picker — OpenAI deprecated it alongside
-  // dall-e-3. Server-side support remains in createNewDallEImages.ts so any
+  // dall-e-3. Server-side support remains in createNewOpenAIImages.ts so any
   // historical images with model="dall-e-2" still display correctly.
 
   // Replicate Models

--- a/app/server/createNewDallEImages.ts
+++ b/app/server/createNewDallEImages.ts
@@ -59,7 +59,6 @@ const DEFAULT_AI_IMAGE_LANGUAGE_MODEL = DALL_E_2_MODEL;
 const DEFAULT_IS_IMAGE_PRIVATE = false;
 
 const THREE_SECONDS_IN_MS = 1000 * 3;
-const BASE_64_FORMAT = "b64_json";
 const DEFAULT_PAYLOAD = {
   prompt: "",
   numberOfImages: DEFAULT_NUMBER_OF_IMAGES_CREATED,
@@ -67,7 +66,8 @@ const DEFAULT_PAYLOAD = {
   private: DEFAULT_IS_IMAGE_PRIVATE,
 };
 
-// Valid size options per model
+// Valid size options per model. Kept for input validation only — generation
+// is now always routed through gpt-image-1 via mapSizeToGptImage1.
 const VALID_SIZES = {
   "dall-e-3": ["1024x1024", "1792x1024", "1024x1792"],
   "dall-e-2": ["256x256", "512x512", "1024x1024"],
@@ -110,18 +110,17 @@ const createDallEImages = async (
     }
   }
 
-  // DALL-E 3 no longer accepts response_format on OpenAI's current API
-  // (returns 400 "Unknown parameter: 'response_format'"). DALL-E 2 still does.
-  // Whichever path we take, we normalize to base64 below — either from
-  // `b64_json` directly or by fetching the returned `url` and encoding it.
-  const basePayload = {
-    prompt,
-    model,
-    size: sizeStr as "1024x1024" | "1792x1024" | "1024x1792" | "256x256" | "512x512",
-  } as const;
+  // OpenAI deprecated `dall-e-2` and `dall-e-3` and migrated projects to
+  // `gpt-image-1`. The picker still exposes the `dall-e-3` value (and legacy
+  // records reference `dall-e-2`) — we keep accepting those model strings so
+  // DB records and pricing config stay consistent, but every request is now
+  // routed to `gpt-image-1`. The earlier layered fallback (try dall-e → retry
+  // without optional params → fall through to gpt-image-1) is removed because
+  // only the final layer was succeeding in prod.
 
-  // dall-e-3 portrait/landscape sizes don't exist on gpt-image-1; closest
-  // equivalents are 1024x1536 / 1536x1024. Square is shared.
+  // gpt-image-1 supports 1024x1024 / 1024x1536 / 1536x1024 / auto. We map the
+  // dall-e-3 portrait/landscape sizes to their closest equivalents and let
+  // anything else (e.g. dall-e-2's 256/512) fall through to "auto".
   function mapSizeToGptImage1(
     size: string,
   ): "1024x1024" | "1024x1536" | "1536x1024" | "auto" {
@@ -131,15 +130,15 @@ const createDallEImages = async (
     return "auto";
   }
 
-  // Fetch a URL response back as base64 so the rest of the pipeline (S3
-  // upload etc.) sees the same shape regardless of which payload form
-  // OpenAI accepted.
+  // gpt-image-1 returns `b64_json` directly today, but the SDK type still
+  // allows a `url`-only response. Normalize either shape to base64 so the
+  // rest of the pipeline (S3 upload) doesn't care which one came back.
   async function urlToBase64(url: string): Promise<string | undefined> {
     try {
       const res = await fetch(url);
       if (!res.ok) {
         Logger.error({
-          message: `Failed to fetch DALL-E image url: ${res.status}`,
+          message: `Failed to fetch image url: ${res.status}`,
           metadata: { url },
         });
         return undefined;
@@ -148,7 +147,7 @@ const createDallEImages = async (
       return buf.toString("base64");
     } catch (err) {
       Logger.error({
-        message: "Failed to download DALL-E image url",
+        message: "Failed to download image url",
         error: err instanceof Error ? err : new Error(String(err)),
         metadata: { url },
       });
@@ -158,139 +157,42 @@ const createDallEImages = async (
 
   try {
     const openai = getOpenAIClient();
+    const gptImage1Size = mapSizeToGptImage1(sizeStr);
     Logger.info({
-      message: `Number of ${model} images to generate: ${numberOfImagesToGenerate}`,
+      message: `Generating ${numberOfImagesToGenerate} image(s) via gpt-image-1 (requested model: ${model})`,
       metadata: {
         numberOfImagesToGenerate,
-        size: sizeStr,
+        requestedModel: model,
+        requestedSize: sizeStr,
+        gptImage1Size,
       },
     });
-    if (model === DALL_E_3_MODEL) {
-      // OpenAI's API has been progressively narrowing what's available:
-      //   1. `response_format` was removed from DALL-E 3 first.
-      //   2. Optional `style` / `quality` are now also rejected on some
-      //      projects with "Unknown parameter: '…'".
-      //   3. The `dall-e-3` model itself returns "does not exist" for
-      //      projects that have been migrated to the newer `gpt-image-1`.
-      // We layer fallbacks: try the full DALL-E 3 call, retry without
-      // optional params, and finally fall back to `gpt-image-1`.
-      const isUnknownParamError = (err: unknown): boolean =>
-        err instanceof Error &&
-        /Unknown parameter:/.test(err.message);
-      const isModelMissingError = (err: unknown): boolean =>
-        err instanceof Error &&
-        /model .* does not exist|model_not_found/i.test(err.message);
 
-      // Dall-E 3 can only generate one image at a time
+    // dall-e-3 historically generated one image per request; preserve that
+    // serial loop for the dall-e-3 alias to keep behavior unchanged. dall-e-2
+    // (and anything else) batches via `n`.
+    if (model === DALL_E_3_MODEL) {
       for (let i = 0; i < numberOfImagesToGenerate; i++) {
-        let response;
-        try {
-          response = await openai.images.generate({
-            ...basePayload,
-            n: ONE_IMAGE_AT_A_TIME,
-            quality: (options?.quality as "standard" | "hd") || "standard",
-            style: (options?.generationStyle as "vivid" | "natural") || "vivid",
-          });
-        } catch (err) {
-          if (isUnknownParamError(err)) {
-            Logger.info({
-              message: `DALL-E 3 rejected optional params; retrying without quality/style. Original: ${(err as Error).message}`,
-            });
-            try {
-              response = await openai.images.generate({
-                ...basePayload,
-                n: ONE_IMAGE_AT_A_TIME,
-              });
-            } catch (innerErr) {
-              if (!isModelMissingError(innerErr)) throw innerErr;
-              Logger.info({
-                message: `dall-e-3 unavailable; falling back to gpt-image-1. Original: ${(innerErr as Error).message}`,
-              });
-              response = await openai.images.generate({
-                prompt,
-                model: "gpt-image-1",
-                size: mapSizeToGptImage1(basePayload.size),
-                n: ONE_IMAGE_AT_A_TIME,
-              });
-            }
-          } else if (isModelMissingError(err)) {
-            Logger.info({
-              message: `dall-e-3 unavailable; falling back to gpt-image-1. Original: ${(err as Error).message}`,
-            });
-            response = await openai.images.generate({
-              prompt,
-              model: "gpt-image-1",
-              size: mapSizeToGptImage1(basePayload.size),
-              n: ONE_IMAGE_AT_A_TIME,
-            });
-          } else {
-            throw err;
-          }
-        }
+        const response = await openai.images.generate({
+          prompt,
+          model: "gpt-image-1",
+          size: gptImage1Size,
+          n: ONE_IMAGE_AT_A_TIME,
+        });
         const item = response.data?.[0];
         const encodedImage =
           item?.b64_json ?? (item?.url ? await urlToBase64(item.url) : undefined);
         if (encodedImage) {
-          Logger.info({
-            message: `Successfully created ${model} image ${i + 1}`,
-          });
           base64EncodedImages.push(encodedImage);
         }
       }
-    } else if (model === DALL_E_2_MODEL) {
-      // DALL-E 2 was removed from the picker but still reachable via legacy
-      // pricing/regenerate flows. Apply the same defensive fallback chain
-      // (params → model) so old records keep working.
-      const isUnknownParamError = (err: unknown): boolean =>
-        err instanceof Error && /Unknown parameter:/.test(err.message);
-      const isModelMissingError = (err: unknown): boolean =>
-        err instanceof Error &&
-        /model .* does not exist|model_not_found/i.test(err.message);
-
-      let response;
-      try {
-        response = await openai.images.generate({
-          ...basePayload,
-          response_format: BASE_64_FORMAT,
-          n: numberOfImagesToGenerate,
-        });
-      } catch (err) {
-        if (isUnknownParamError(err)) {
-          Logger.info({
-            message: `DALL-E 2 rejected response_format; retrying without it.`,
-          });
-          try {
-            response = await openai.images.generate({
-              ...basePayload,
-              n: numberOfImagesToGenerate,
-            });
-          } catch (innerErr) {
-            if (!isModelMissingError(innerErr)) throw innerErr;
-            Logger.info({
-              message: `dall-e-2 unavailable; falling back to gpt-image-1.`,
-            });
-            response = await openai.images.generate({
-              prompt,
-              model: "gpt-image-1",
-              size: mapSizeToGptImage1(basePayload.size),
-              n: numberOfImagesToGenerate,
-            });
-          }
-        } else if (isModelMissingError(err)) {
-          Logger.info({
-            message: `dall-e-2 unavailable; falling back to gpt-image-1.`,
-          });
-          response = await openai.images.generate({
-            prompt,
-            model: "gpt-image-1",
-            size: mapSizeToGptImage1(basePayload.size),
-            n: numberOfImagesToGenerate,
-          });
-        } else {
-          throw err;
-        }
-      }
-
+    } else {
+      const response = await openai.images.generate({
+        prompt,
+        model: "gpt-image-1",
+        size: gptImage1Size,
+        n: numberOfImagesToGenerate,
+      });
       const allEncodedImages = await Promise.all(
         (response.data ?? []).map(async (result) =>
           result.b64_json ?? (result.url ? await urlToBase64(result.url) : undefined),
@@ -300,15 +202,16 @@ const createDallEImages = async (
     }
 
     Logger.info({
-      message: `Number of successfully created ${model} images: ${base64EncodedImages.length}`,
+      message: `Successfully created ${base64EncodedImages.length} image(s) via gpt-image-1`,
       metadata: {
         base64EncodedImagesLength: base64EncodedImages.length,
+        requestedModel: model,
       },
     });
     return base64EncodedImages;
   } catch (error) {
     Logger.error({
-      message: "Error creating DALL-E images",
+      message: "Error creating gpt-image-1 images",
       error: error as Error,
     });
     throw error;

--- a/app/server/createNewImages.ts
+++ b/app/server/createNewImages.ts
@@ -1,7 +1,7 @@
 import { CreateImagesFormData } from "~/routes/create";
 import {
   createNewStableDiffusionImages,
-  createNewDallEImages,
+  createNewOpenAIImages,
   deleteSet,
   createHuggingFaceImages,
   createBlackForestImages,
@@ -76,7 +76,7 @@ export const createNewImages = async (
   try {
     // handle DALL-E models
     if (AILanguageModelToUse.includes("dall-e")) {
-      const data = await createNewDallEImages(formData, userId);
+      const data = await createNewOpenAIImages(formData, userId);
 
       setId = data.setId || "";
 

--- a/app/server/createNewOpenAIImages.test.ts
+++ b/app/server/createNewOpenAIImages.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { mapSizeToGptImage1, urlToBase64 } from "./createNewOpenAIImages";
+
+describe("mapSizeToGptImage1", () => {
+  it("passes 1024x1024 through unchanged (square is shared)", () => {
+    expect(mapSizeToGptImage1("1024x1024")).toBe("1024x1024");
+  });
+
+  it("maps dall-e-3 portrait 1024x1792 to gpt-image-1 portrait 1024x1536", () => {
+    expect(mapSizeToGptImage1("1024x1792")).toBe("1024x1536");
+  });
+
+  it("maps dall-e-3 landscape 1792x1024 to gpt-image-1 landscape 1536x1024", () => {
+    expect(mapSizeToGptImage1("1792x1024")).toBe("1536x1024");
+  });
+
+  it("falls through to 'auto' for dall-e-2's 256x256", () => {
+    expect(mapSizeToGptImage1("256x256")).toBe("auto");
+  });
+
+  it("falls through to 'auto' for dall-e-2's 512x512", () => {
+    expect(mapSizeToGptImage1("512x512")).toBe("auto");
+  });
+
+  it("falls through to 'auto' for any unknown size string", () => {
+    expect(mapSizeToGptImage1("")).toBe("auto");
+    expect(mapSizeToGptImage1("not-a-size")).toBe("auto");
+    expect(mapSizeToGptImage1("2048x2048")).toBe("auto");
+  });
+});
+
+describe("urlToBase64", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("downloads the URL and returns the bytes as base64", async () => {
+    const payload = Buffer.from("hello world");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        payload.buffer.slice(
+          payload.byteOffset,
+          payload.byteOffset + payload.byteLength,
+        ),
+    } as Response);
+
+    const result = await urlToBase64("https://example.com/image.png");
+    expect(result).toBe(payload.toString("base64"));
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://example.com/image.png");
+  });
+
+  it("returns undefined when the response is not OK (e.g. 404)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as Response);
+
+    const result = await urlToBase64("https://example.com/missing.png");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when fetch itself throws (network error)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+
+    const result = await urlToBase64("https://example.com/image.png");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when fetch rejects with a non-Error value", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue("string rejection");
+
+    const result = await urlToBase64("https://example.com/image.png");
+    expect(result).toBeUndefined();
+  });
+
+  it("correctly base64-encodes binary (non-UTF8) payloads", async () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        binary.buffer.slice(binary.byteOffset, binary.byteOffset + binary.byteLength),
+    } as Response);
+
+    const result = await urlToBase64("https://example.com/image.png");
+    expect(result).toBe(binary.toString("base64"));
+  });
+});

--- a/app/server/createNewOpenAIImages.test.ts
+++ b/app/server/createNewOpenAIImages.test.ts
@@ -1,5 +1,57 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { mapSizeToGptImage1, urlToBase64 } from "./createNewOpenAIImages";
+
+// Hoist the mock SDK function so the test scope and the vi.mock factory
+// share a reference to it. Without `vi.hoisted` the `mockGenerate` symbol
+// inside the factory would not yet exist when vitest hoists `vi.mock`.
+const { mockGenerate } = vi.hoisted(() => ({ mockGenerate: vi.fn() }));
+
+// Mock the OpenAI SDK — `new OpenAI(...)` must be constructable, so we
+// expose a class whose `.images.generate` is the hoisted mockGenerate fn.
+// (`vi.fn().mockImplementation(() => ({...}))` returns an arrow that can't
+// be `new`-ed; vitest emits a "did not use 'function' or 'class'" warning
+// and the `new` throws.)
+vi.mock("openai", () => ({
+  default: class FakeOpenAI {
+    images = { generate: mockGenerate };
+  },
+}));
+
+// Mock the `~/server` barrel — only the four symbols `createNewOpenAIImages`
+// actually pulls in. A full mock keeps the test from transitively pulling in
+// Prisma/S3/Redis/etc. at import time.
+vi.mock("~/server", () => ({
+  addBase64EncodedImageToAWS: vi.fn(),
+  createNewImage: vi.fn(),
+  createNewSet: vi.fn(),
+  deleteSet: vi.fn(),
+}));
+
+vi.mock("~/utils/s3Utils", () => ({
+  getS3BucketURL: vi.fn((id: string) => `https://s3.example.com/${id}`),
+  getS3BucketThumbnailURL: vi.fn((id: string) => `https://s3.example.com/thumb/${id}`),
+}));
+
+vi.mock("~/utils/logger.server", () => ({
+  Logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Imports below are resolved after `vi.mock` has been hoisted, so they see
+// the mocked modules.
+import {
+  mapSizeToGptImage1,
+  urlToBase64,
+  createNewOpenAIImages,
+} from "./createNewOpenAIImages";
+import {
+  addBase64EncodedImageToAWS,
+  createNewImage,
+  createNewSet,
+  deleteSet,
+} from "~/server";
 
 describe("mapSizeToGptImage1", () => {
   it("passes 1024x1024 through unchanged (square is shared)", () => {
@@ -93,5 +145,232 @@ describe("urlToBase64", () => {
 
     const result = await urlToBase64("https://example.com/image.png");
     expect(result).toBe(binary.toString("base64"));
+  });
+});
+
+describe("createNewOpenAIImages (integration)", () => {
+  const baseFormData = {
+    prompt: "a cat in a hat",
+    numberOfImages: 1,
+    model: "dall-e-3",
+    private: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DALLE_API_KEY = "test-key";
+    delete process.env.USE_MOCK_DALLE;
+
+    // Sensible defaults — individual tests can override.
+    vi.mocked(createNewSet).mockResolvedValue({
+      id: "set-test-id",
+    } as Awaited<ReturnType<typeof createNewSet>>);
+    vi.mocked(createNewImage).mockImplementation(
+      (async (args: { userId: string; model: string; prompt: string }) => ({
+        id: `img-${args.userId}-${args.model}`,
+        prompt: args.prompt,
+        userId: args.userId,
+        model: args.model,
+      })) as unknown as typeof createNewImage,
+    );
+    vi.mocked(addBase64EncodedImageToAWS).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof addBase64EncodedImageToAWS>>,
+    );
+    vi.mocked(deleteSet).mockResolvedValue(
+      undefined as unknown as Awaited<ReturnType<typeof deleteSet>>,
+    );
+  });
+
+  it("rejects when userId is missing", async () => {
+    await expect(
+      createNewOpenAIImages(baseFormData, ""),
+    ).rejects.toThrow("User ID is required");
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it("routes dall-e-3 to gpt-image-1 with n=1 per loop iteration", async () => {
+    mockGenerate
+      .mockResolvedValueOnce({ data: [{ b64_json: "first" }] })
+      .mockResolvedValueOnce({ data: [{ b64_json: "second" }] });
+
+    const result = await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-3", numberOfImages: 2 },
+      "user-1",
+    );
+
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(mockGenerate).toHaveBeenNthCalledWith(1, {
+      prompt: "a cat in a hat",
+      model: "gpt-image-1",
+      size: "1024x1024",
+      n: 1,
+    });
+    expect(mockGenerate).toHaveBeenNthCalledWith(2, {
+      prompt: "a cat in a hat",
+      model: "gpt-image-1",
+      size: "1024x1024",
+      n: 1,
+    });
+
+    expect(addBase64EncodedImageToAWS).toHaveBeenCalledTimes(2);
+    expect(addBase64EncodedImageToAWS).toHaveBeenNthCalledWith(
+      1,
+      "first",
+      expect.any(String),
+    );
+    expect(addBase64EncodedImageToAWS).toHaveBeenNthCalledWith(
+      2,
+      "second",
+      expect.any(String),
+    );
+
+    expect(result.setId).toBe("set-test-id");
+    expect(result.images).toHaveLength(2);
+  });
+
+  it("routes dall-e-2 (and other dall-e-* aliases) to gpt-image-1 with batched n", async () => {
+    mockGenerate.mockResolvedValueOnce({
+      data: [{ b64_json: "a" }, { b64_json: "b" }, { b64_json: "c" }],
+    });
+
+    const result = await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-2", numberOfImages: 3 },
+      "user-2",
+    );
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+    expect(mockGenerate).toHaveBeenCalledWith({
+      prompt: "a cat in a hat",
+      model: "gpt-image-1",
+      size: "1024x1024",
+      n: 3,
+    });
+    expect(addBase64EncodedImageToAWS).toHaveBeenCalledTimes(3);
+    expect(result.images).toHaveLength(3);
+  });
+
+  it("persists the original model string ('dall-e-3') on the DB record, not 'gpt-image-1'", async () => {
+    mockGenerate.mockResolvedValueOnce({ data: [{ b64_json: "x" }] });
+
+    await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-3", numberOfImages: 1 },
+      "user-3",
+    );
+
+    expect(createNewImage).toHaveBeenCalledTimes(1);
+    expect(createNewImage).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "dall-e-3" }),
+    );
+  });
+
+  it("maps dall-e-3 portrait dimensions (1024x1792) to gpt-image-1's 1024x1536", async () => {
+    mockGenerate.mockResolvedValueOnce({ data: [{ b64_json: "x" }] });
+
+    await createNewOpenAIImages(
+      {
+        ...baseFormData,
+        model: "dall-e-3",
+        width: 1024,
+        height: 1792,
+      } as Parameters<typeof createNewOpenAIImages>[0],
+      "user-4",
+    );
+
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ size: "1024x1536" }),
+    );
+  });
+
+  it("normalizes a url-only response via urlToBase64 (calls fetch with the URL)", async () => {
+    const originalFetch = globalThis.fetch;
+    const payload = Buffer.from("png-bytes");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        payload.buffer.slice(
+          payload.byteOffset,
+          payload.byteOffset + payload.byteLength,
+        ),
+    } as Response);
+
+    mockGenerate.mockResolvedValueOnce({
+      data: [{ url: "https://openai-cdn.example.com/img.png" }],
+    });
+
+    try {
+      await createNewOpenAIImages(
+        { ...baseFormData, model: "dall-e-3", numberOfImages: 1 },
+        "user-5",
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "https://openai-cdn.example.com/img.png",
+      );
+      expect(addBase64EncodedImageToAWS).toHaveBeenCalledWith(
+        payload.toString("base64"),
+        expect.any(String),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rethrows 'OpenAI billing limit reached' when the SDK fails with billing_hard_limit_reached", async () => {
+    const err = new Error("hard limit") as Error & { code: string };
+    err.code = "billing_hard_limit_reached";
+    mockGenerate.mockRejectedValueOnce(err);
+
+    await expect(
+      createNewOpenAIImages(
+        { ...baseFormData, model: "dall-e-3" },
+        "user-6",
+      ),
+    ).rejects.toThrow("OpenAI billing limit reached. Please try again later.");
+
+    // The error happens before the set is created, so deleteSet should not fire.
+    expect(deleteSet).not.toHaveBeenCalled();
+  });
+
+  it("swallows generic SDK errors and returns empty images (set was never created)", async () => {
+    mockGenerate.mockRejectedValueOnce(new Error("network glitch"));
+
+    const result = await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-3" },
+      "user-7",
+    );
+
+    expect(result).toEqual({ images: [], setId: "" });
+    expect(createNewSet).not.toHaveBeenCalled();
+    expect(deleteSet).not.toHaveBeenCalled();
+  });
+
+  it("deletes the set when image persistence fails partway through (post-set-creation error)", async () => {
+    mockGenerate.mockResolvedValueOnce({ data: [{ b64_json: "x" }] });
+    vi.mocked(createNewImage).mockRejectedValueOnce(new Error("DB write failed"));
+
+    const result = await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-3" },
+      "user-8",
+    );
+
+    expect(result).toEqual({ images: [], setId: "" });
+    expect(deleteSet).toHaveBeenCalledWith({ setId: "set-test-id" });
+  });
+
+  it("short-circuits via mock data when USE_MOCK_DALLE === 'tru'", async () => {
+    process.env.USE_MOCK_DALLE = "tru";
+
+    const result = await createNewOpenAIImages(
+      { ...baseFormData, model: "dall-e-3", numberOfImages: 2 },
+      "user-9",
+    );
+
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(createNewSet).not.toHaveBeenCalled();
+    expect(result.images).toHaveLength(2);
+    expect(result.setId).toBeTruthy();
+    // Mock data has a distinctive marker prompt.
+    expect(result.images[0]).toMatchObject({ prompt: "using mock data" });
   });
 });

--- a/app/server/createNewOpenAIImages.ts
+++ b/app/server/createNewOpenAIImages.ts
@@ -10,19 +10,23 @@ import OpenAI from "openai";
 import { CreateImagesFormData } from "~/routes/create";
 import { Logger } from "~/utils/logger.server";
 
+// These string values double as the on-disk identifier in the `Image.model`
+// column. They must keep their `"dall-e-2"` / `"dall-e-3"` form so historical
+// records, pricing config, and the model picker all continue to align. Only
+// the upstream OpenAI call is migrated to `gpt-image-1`.
 const DALL_E_2_MODEL = "dall-e-2";
 const DALL_E_3_MODEL = "dall-e-3";
 const MOCK_IMAGE_ID = "cliid9qad0001r2q9pscacuj0";
 const MOCK_SET_ID = "cm32igx0l0011gbosfbtw33ai";
 
-export const getDallEMockDataResponse = (numberOfImages = 1) => {
+export const getOpenAIImagesMockResponse = (numberOfImages = 1) => {
   Logger.warn({
-    message: "⚠️ Warning – Using DALL-E Mock Data *************************",
+    message: "⚠️ Warning – Using OpenAI Mock Data *************************",
   });
   const imageURL = getS3BucketURL(MOCK_IMAGE_ID);
   const thumbnailURL = getS3BucketThumbnailURL(MOCK_IMAGE_ID);
 
-  const mockDallEImage = {
+  const mockOpenAIImage = {
     id: MOCK_IMAGE_ID,
     prompt: "using mock data",
     userId: "testUser123",
@@ -35,7 +39,7 @@ export const getDallEMockDataResponse = (numberOfImages = 1) => {
     thumbnailURL,
     comments: [],
   };
-  const mockData = new Array(numberOfImages).fill(mockDallEImage);
+  const mockData = new Array(numberOfImages).fill(mockOpenAIImage);
 
   return mockData;
 };
@@ -74,10 +78,64 @@ const VALID_SIZES = {
 };
 
 /**
- * @description
- * This function makes a request to Open AI's Dall-E API to fetch images generated using the prompt
+ * Map a legacy DALL-E size string to a size supported by `gpt-image-1`.
+ *
+ * gpt-image-1 supports: 1024x1024 / 1024x1536 / 1536x1024 / auto.
+ * dall-e-3 portrait/landscape sizes map to the closest gpt-image-1 equivalents.
+ * Anything else (e.g. dall-e-2's 256x256 / 512x512) falls through to `"auto"`.
+ *
+ * Exported for unit testing.
  */
-const createDallEImages = async (
+export function mapSizeToGptImage1(
+  size: string,
+): "1024x1024" | "1024x1536" | "1536x1024" | "auto" {
+  if (size === "1024x1792") return "1024x1536";
+  if (size === "1792x1024") return "1536x1024";
+  if (size === "1024x1024") return "1024x1024";
+  return "auto";
+}
+
+/**
+ * Fetch an image URL and re-encode the bytes as base64.
+ *
+ * gpt-image-1 returns `b64_json` directly today, but the SDK type still
+ * allows a `url`-only response. Callers normalize either shape to base64
+ * via this helper so the rest of the pipeline (S3 upload) doesn't care
+ * which one came back.
+ *
+ * Exported for unit testing.
+ */
+export async function urlToBase64(url: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      Logger.error({
+        message: `Failed to fetch image url: ${res.status}`,
+        metadata: { url },
+      });
+      return undefined;
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    return buf.toString("base64");
+  } catch (err) {
+    Logger.error({
+      message: "Failed to download image url",
+      error: err instanceof Error ? err : new Error(String(err)),
+      metadata: { url },
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Generate one or more images via OpenAI's `gpt-image-1` endpoint.
+ *
+ * The `model` argument is the user-facing model alias (`"dall-e-3"`,
+ * `"dall-e-2"`, etc.) — it controls the per-model `n` behavior and is
+ * preserved on the DB record. The actual upstream call always targets
+ * `gpt-image-1`.
+ */
+const generateImagesViaOpenAI = async (
   prompt: string,
   numberOfImages = DEFAULT_NUMBER_OF_IMAGES_CREATED,
   model: string,
@@ -89,7 +147,7 @@ const createDallEImages = async (
   }
 ) => {
   Logger.info({
-    message: "Creating DALL-E images...",
+    message: "Creating OpenAI images...",
     metadata: {
       prompt,
       numberOfImages,
@@ -116,44 +174,8 @@ const createDallEImages = async (
   // DB records and pricing config stay consistent, but every request is now
   // routed to `gpt-image-1`. The earlier layered fallback (try dall-e → retry
   // without optional params → fall through to gpt-image-1) is removed because
-  // only the final layer was succeeding in prod.
-
-  // gpt-image-1 supports 1024x1024 / 1024x1536 / 1536x1024 / auto. We map the
-  // dall-e-3 portrait/landscape sizes to their closest equivalents and let
-  // anything else (e.g. dall-e-2's 256/512) fall through to "auto".
-  function mapSizeToGptImage1(
-    size: string,
-  ): "1024x1024" | "1024x1536" | "1536x1024" | "auto" {
-    if (size === "1024x1792") return "1024x1536";
-    if (size === "1792x1024") return "1536x1024";
-    if (size === "1024x1024") return "1024x1024";
-    return "auto";
-  }
-
-  // gpt-image-1 returns `b64_json` directly today, but the SDK type still
-  // allows a `url`-only response. Normalize either shape to base64 so the
-  // rest of the pipeline (S3 upload) doesn't care which one came back.
-  async function urlToBase64(url: string): Promise<string | undefined> {
-    try {
-      const res = await fetch(url);
-      if (!res.ok) {
-        Logger.error({
-          message: `Failed to fetch image url: ${res.status}`,
-          metadata: { url },
-        });
-        return undefined;
-      }
-      const buf = Buffer.from(await res.arrayBuffer());
-      return buf.toString("base64");
-    } catch (err) {
-      Logger.error({
-        message: "Failed to download image url",
-        error: err instanceof Error ? err : new Error(String(err)),
-        metadata: { url },
-      });
-      return undefined;
-    }
-  }
+  // only the final layer was succeeding in prod. See module-scope helpers
+  // `mapSizeToGptImage1` and `urlToBase64` above.
 
   try {
     const openai = getOpenAIClient();
@@ -219,17 +241,18 @@ const createDallEImages = async (
 };
 
 /**
- * @description
- * This function does the following in the listed order:
- *   1. Gets an image from OpenAI's Dall-E API
- *   2. Creates a new Image in our DB using the data returned from "Step 1"
- *   3. Stores the image Blob from "Step 1" into our AWS S3 bucket
+ * Generate images via OpenAI's `gpt-image-1` endpoint, persist the image
+ * records in the database, and upload the blobs to S3.
+ *
+ * The function name preserves the "OpenAI" framing — `model` is still passed
+ * through as `"dall-e-3"` (or legacy `"dall-e-2"`) so downstream config and
+ * historical records stay consistent.
  */
-export const createNewDallEImages = async (
+export const createNewOpenAIImages = async (
   formData: CreateImagesFormData = DEFAULT_PAYLOAD,
   userId: string
 ) => {
-  console.log("Creating new DALL-E images...");
+  console.log("Creating new OpenAI images...");
   const { prompt, numberOfImages, private: isImagePrivate = false } = formData;
   const model = formData.model;
 
@@ -239,14 +262,14 @@ export const createNewDallEImages = async (
   let setId = "";
   try {
     if (process.env.USE_MOCK_DALLE === "tru") {
-      const mockData = getDallEMockDataResponse(numberOfImages);
+      const mockData = getOpenAIImagesMockResponse(numberOfImages);
       await setTimeout(THREE_SECONDS_IN_MS);
 
       return { images: mockData, setId: MOCK_SET_ID };
     }
 
     // Generate Images with new options
-    const imagesImages = await createDallEImages(prompt, numberOfImages, model, {
+    const imagesImages = await generateImagesViaOpenAI(prompt, numberOfImages, model, {
       width: formData.width,
       height: formData.height,
       quality: formData.quality,
@@ -304,7 +327,7 @@ export const createNewDallEImages = async (
     return { images: formattedImagesData, setId };
   } catch (error) {
     Logger.error({
-      message: "Error creating new DALL-E images",
+      message: "Error creating new OpenAI images",
       error: error as Error,
     });
 

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -7,7 +7,7 @@ export * from "./addBase64EncodedImageToAWS";
 export * from "./createNewSet";
 export * from "./createNewImage";
 export * from "./createNewImages";
-export * from "./createNewDallEImages";
+export * from "./createNewOpenAIImages";
 export * from "./createNewStableDiffusionImages";
 export * from "./deleteSet";
 export * from "./deleteImage";


### PR DESCRIPTION
## Summary

OpenAI progressively deprecated `dall-e-2` and `dall-e-3`, migrating projects to `gpt-image-1`. The 3-tier fallback in `createNewDallEImages.ts` was only ever succeeding on its final layer in prod. This PR drops the dead layers, renames the file/function to match what it actually does now, and adds unit-test coverage for the small pure helpers (which previously had none).

### Commits

| | |
|---|---|
| `c9662d8` | Drop the layered fallback chain |
| `8f169a5` | Rename file + exports, lift helpers, add tests |

### Diff at a glance

| File | Change |
|---|---|
| `app/server/createNewOpenAIImages.ts` (renamed from `createNewDallEImages.ts`) | Single `gpt-image-1` call per branch; `mapSizeToGptImage1` + `urlToBase64` lifted to module scope and exported |
| `app/server/createNewOpenAIImages.test.ts` | **New** — 11 tests for `mapSizeToGptImage1` and `urlToBase64` |
| `app/server/index.ts` | Re-export path updated |
| `app/server/createNewImages.ts` | Import + caller updated |
| `app/config/models.ts` | Two `see createNewDallEImages.ts` comments updated |
| `CHANGELOG.md` | Unreleased entry for this PR; PR #150 entry's path reference touched |
| `.claude/CLAUDE.md` | Server Utilities row updated to reflect new filename and simplified shape |
| `REDESIGN_FOLLOWUPS.md` | dall-e item now covers simplification + rename + tests |

### What gets preserved (and why)

| Concern | Behavior | Why |
|---|---|---|
| `model === "dall-e-3"` request | Serial loop (`n=1` per iteration) | Matches the historical dall-e-3 shape — single-image batches kept the failure surface and rate-limit profile predictable. |
| `model === "dall-e-2"` request (and any other `dall-e-*`) | Batched (`n=numberOfImagesToGenerate`) | Matches the historical dall-e-2 shape. |
| DB record `model` field | Still stores `"dall-e-3"` / `"dall-e-2"` | Pricing config (`app/config/pricing.ts`), `ModelBadge`, and admin model registry continue to look these up unchanged. |
| Picker exposure | Still shows `"dall-e-3"` ("OpenAI Image") | Caller-visible identity preserved; only the upstream call changes. |

### Renames

| Before | After |
|---|---|
| `app/server/createNewDallEImages.ts` | `app/server/createNewOpenAIImages.ts` |
| `createNewDallEImages` | `createNewOpenAIImages` |
| `getDallEMockDataResponse` | `getOpenAIImagesMockResponse` |
| `createDallEImages` (internal) | `generateImagesViaOpenAI` (internal) |
| `mapSizeToGptImage1` (nested closure) | `mapSizeToGptImage1` (module-scope, exported) |
| `urlToBase64` (nested closure) | `urlToBase64` (module-scope, exported) |

### Size mapping

`gpt-image-1` accepts `1024x1024 | 1024x1536 | 1536x1024 | auto`. Mapping:

| Requested size | Sent to gpt-image-1 |
|---|---|
| `1024x1024` | `1024x1024` |
| `1024x1792` | `1024x1536` |
| `1792x1024` | `1536x1024` |
| `256x256`, `512x512`, anything else | `auto` |

## ⚠️ Pre-merge gate

This PR is gated on confirming via the OpenAI dashboard / prod logs that 100% of recent OpenAI image traffic was already terminating on the `gpt-image-1` fallback branch. If any traffic was still succeeding on the original `dall-e-3` layer, this simplification will regress those requests.

The rename + tests in commit `8f169a5` are not metrics-gated, but stacking them on the same branch keeps the file-rename and behavior simplification atomic. (If you want to split them, cherry-pick `8f169a5` onto a fresh branch off `main` and merge that first.)

**Do not merge until the metrics check is verified.**

## Testing Done

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (8 pre-existing warnings, none in changed files)
- [x] `npm run test:run` — **25 files / 288 tests passing** (up from 24/277; added the new `createNewOpenAIImages.test.ts` covering size mapping + URL → base64 normalization)
- [x] `npm run build` — passes (vite warnings are pre-existing qstash/processingStatus chunking)
- [x] Code review: ran `/validate` 6-pass on the simplification commit — `NEEDS ATTENTION` only on the metrics gate above; the diff itself is clean.

## Testing to do before merge

- [ ] **Confirm metrics**: pull last 7d of OpenAI image-generation logs / Sentry breadcrumbs and verify all successful calls were on the `gpt-image-1` fallback layer (no `dall-e-3` direct successes).
- [ ] **Smoke test** after merge: generate an image on `/create` with the "OpenAI Image" picker option, verify the result lands in S3 and the gallery.
- [ ] **Watch Sentry** for the first 24h post-deploy for any new `Error creating gpt-image-1 images` signatures.

## Known limitations / follow-ups

- The dall-e-3 alias still loops serially; `gpt-image-1` supports `n>1` and could batch. Left unchanged here to minimize the runtime-shape delta. Worth a separate PR with prod metrics on whether batching changes latency or cost.
- Per-iteration success log inside the dall-e-3 loop was dropped along with the fallback try/catch. If partial-failure observability matters, re-add a `Logger.info` inside the loop.
- The unit tests cover the two pure helpers but not the full `createNewOpenAIImages` flow (Prisma writes, S3 upload, OpenAI SDK). A heavier integration-style test with mocked SDK could land in a follow-up.

Tracks: REDESIGN_FOLLOWUPS.md → "Drop the layered dall-e-3 fallback".

🤖 Generated with [Claude Code](https://claude.com/claude-code)