### PR TITLE
Remove stats strip and update landing page messaging

### DIFF
--- a/app/pages/LandingPage.tsx
+++ b/app/pages/LandingPage.tsx
@@ -80,13 +80,6 @@ const EXAMPLE_PROMPTS = [
   "Bioluminescent forest at night",
 ];
 
-const STATS = [
-  { value: "1.9M", label: "creations" },
-  { value: "12,000+", label: "creators" },
-  { value: "12", label: "models" },
-  { value: "4.9★", label: "rating" },
-];
-
 const FEATURES = [
   {
     icon: <Cpu className="h-5 w-5" />,
@@ -314,7 +307,7 @@ export default function LandingPage() {
         <div className="mx-auto grid w-full max-w-[1280px] gap-12 px-4 py-16 md:grid-cols-[1.1fr_1fr] md:px-8 md:py-24">
           <div>
             <Badge tone="accent" icon={<Sparkles className="h-3 w-3" />}>
-              1.9M creations and counting
+              12 leading AI models, one workspace
             </Badge>
             <h1 className="mt-5 text-[44px] font-bold leading-[1.02] tracking-[-0.035em] md:text-[64px]">
               Create stunning{" "}
@@ -381,7 +374,7 @@ export default function LandingPage() {
                 ))}
               </div>
               <p className="text-[13px] text-fg-muted">
-                Joined by 12,000+ creators this month
+                Join a growing community of creators
               </p>
             </div>
           </div>
@@ -414,20 +407,6 @@ export default function LandingPage() {
               delay={1}
             />
           </div>
-        </div>
-      </section>
-
-      {/* Stats strip */}
-      <section className="border-y border-[var(--border)] bg-surface-1">
-        <div className="mx-auto grid w-full max-w-[1280px] grid-cols-2 gap-6 px-4 py-10 md:grid-cols-4 md:px-8">
-          {STATS.map((s) => (
-            <div key={s.label}>
-              <div className="mono text-[32px] font-bold leading-none tracking-[-0.02em] text-fg">
-                {s.value}
-              </div>
-              <div className="mt-1 text-[12.5px] text-fg-subtle">{s.label}</div>
-            </div>
-          ))}
         </div>
       </section>
 

--- a/tests/redesign-smoke.spec.ts
+++ b/tests/redesign-smoke.spec.ts
@@ -14,7 +14,9 @@ test.describe("Landing (redesign)", () => {
     await page.goto("/");
 
     // Hero badge — proves the new Badge primitive renders
-    await expect(page.getByText("1.9M creations and counting")).toBeVisible();
+    await expect(
+      page.getByText("12 leading AI models, one workspace")
+    ).toBeVisible();
 
     // Hero H1 split — "Create stunning" + gradient "art & video"
     await expect(
@@ -23,10 +25,6 @@ test.describe("Landing (redesign)", () => {
 
     // Auto-typing prompt input area (text shows up after typewriter tick)
     await expect(page.getByRole("link", { name: /generate/i }).first()).toBeVisible();
-
-    // Stats strip
-    await expect(page.getByText("1.9M", { exact: true })).toBeVisible();
-    await expect(page.getByText("creators", { exact: true })).toBeVisible();
 
     // Features grid — at least one feature title shows
     await expect(


### PR DESCRIPTION
## Summary

Removed the stats strip section from the landing page and updated key messaging to focus on AI model capabilities rather than user metrics. This includes:

- Removed the `STATS` constant and its associated section rendering
- Updated the hero badge from "1.9M creations and counting" to "12 leading AI models, one workspace"
- Changed the signup CTA text from "Joined by 12,000+ creators this month" to "Join a growing community of creators"
- Updated corresponding smoke tests to reflect the new messaging

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing Steps

1. Navigate to the landing page (`/`)
2. Verify the hero badge displays "12 leading AI models, one workspace"
3. Verify the stats strip section is no longer visible
4. Verify the signup section shows "Join a growing community of creators"
5. Run smoke tests: `npm run test:e2e`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have updated tests that prove my changes work
- [x] Existing unit tests pass locally with my changes

## Additional Notes

The stats strip removal simplifies the landing page layout while the messaging updates shift focus from vanity metrics (user counts, creation volume) to the core product value proposition (multiple AI models in one workspace). The smoke tests have been updated to verify the new messaging is displayed correctly.

https://claude.ai/code/session_01FC7MwnDCJvhbSvtTCoirKd