### PR TITLE
fix(auth): centralize ORIGIN into a trimmed constant to prevent malformed URLs

### DIFF
--- a/app/routes/auth.v2.google.ts
+++ b/app/routes/auth.v2.google.ts
@@ -7,6 +7,7 @@ import {
   getRateLimitIdentifier,
   rateLimitResponse,
 } from "~/services/rateLimit.server";
+import { ORIGIN } from "~/utils/env.server";
 
 export async function action({ request }: ActionFunctionArgs) {
   const rl = await checkRateLimit(
@@ -22,10 +23,9 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   try {
-    const siteUrl = process.env.ORIGIN?.trim() || "http://localhost:5173";
-    const redirectUrl = new URL("/auth/v2/callback-google", siteUrl).toString();
+    const redirectUrl = new URL("/auth/v2/callback-google", ORIGIN).toString();
 
-    console.log("Site URL:", siteUrl);
+    console.log("Site URL:", ORIGIN);
     console.log("Using redirect URL:", redirectUrl);
 
     const { data, error } = await supabase.auth.signInWithOAuth({

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -14,6 +14,7 @@ import {
   getSupabaseWithHeaders,
   signOutOfSupabase,
 } from "~/services/supabase.server";
+import { ORIGIN } from "~/utils/env.server";
 export const AUTH_KEY = "_auth";
 // ? Placeholder for GOOGLE_SESSION_KEY
 // export const GOOGLE_SESSION_KEY = "_google_auth";
@@ -29,7 +30,7 @@ export const authenticator = new Authenticator(sessionStorage, {
 
 // const getCallback = (provider: SocialsProvider) => {
 const getCallback = (provider: string) => {
-  return `${process.env.ORIGIN}/auth/${provider}/callback`;
+  return `${ORIGIN}/auth/${provider}/callback`;
 };
 
 authenticator.use(

--- a/app/services/stripe.server.ts
+++ b/app/services/stripe.server.ts
@@ -1,6 +1,7 @@
 import Stripe from "stripe";
 import { json } from "@remix-run/node";
 import { Logger } from "~/utils/logger.server";
+import { ORIGIN } from "~/utils/env.server";
 
 const isTestEnvironment = process.env.CI === "true" || process.env.NODE_ENV === "test";
 const hasStripeCredentials = !!process.env.STRIPE_SECRET_KEY;
@@ -30,8 +31,8 @@ export const stripeCheckout = async ({ userId }: { userId: string }) => {
     });
 
     const session = await stripe.checkout.sessions.create({
-      success_url: `${process.env.ORIGIN}/create`,
-      cancel_url: `${process.env.ORIGIN}/create`,
+      success_url: `${ORIGIN}/create`,
+      cancel_url: `${ORIGIN}/create`,
       line_items: [{ price: process.env.STRIPE_CREDITS_PRICE_ID, quantity: 1 }],
       mode: "payment",
       metadata: {

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -16,6 +16,15 @@ declare global {
   }
 }
 
+/**
+ * Canonical app origin, e.g. `https://www.pixelstudioai.com`.
+ *
+ * Trimmed because a stray leading/trailing space in the `ORIGIN` env var yields
+ * a malformed URL; downstream OAuth redirect and callback URLs built from it
+ * then fail to parse (a whitespace-prefixed value breaks `URL`/GoTrue parsing).
+ */
+export const ORIGIN = process.env.ORIGIN?.trim() || "http://localhost:5173";
+
 export function init() {
   const parsed = schema.safeParse(process.env);
 


### PR DESCRIPTION
## Summary

Route every `process.env.ORIGIN` read through a single trimmed constant so a stray leading/trailing space in the env var can no longer produce malformed OAuth redirect or Stripe checkout URLs.

This is defense-in-depth for the class of bug behind the recent login outage: a whitespace-prefixed redirect URL was rejected by Supabase GoTrue's URL parser (`first path segment in URL cannot contain colon`), which 500'd every OAuth callback. The outage itself was fixed separately in the Supabase dashboard (the **Site URL** had been left as a whitespace-corrupted localhost test URL); this change hardens the application code paths that build URLs from `ORIGIN` so the same whitespace can't bite elsewhere (the legacy Google callback and Stripe redirects were previously using `ORIGIN` raw).

| File | URL built from `ORIGIN` | Before | After |
|------|--------------------------|--------|-------|
| `app/utils/env.server.ts` | — (new shared constant) | n/a | `ORIGIN = process.env.ORIGIN?.trim() \|\| "http://localhost:5173"` |
| `app/services/auth.server.ts` | legacy Google callback | `${process.env.ORIGIN}/auth/google/callback` (untrimmed, no fallback) | `${ORIGIN}/...` |
| `app/services/stripe.server.ts` | Stripe success/cancel | `${process.env.ORIGIN}/create` (untrimmed, no fallback) | `${ORIGIN}/create` |
| `app/routes/auth.v2.google.ts` | Supabase v2 callback | local `siteUrl` (already trimmed) | shared `ORIGIN` |

## Testing Done

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes (caught and fixed a dangling `siteUrl` reference)
- [x] `npm run test:run` — 300/300 pass
- [x] `npm run build` — production build succeeds
- [x] Repo-wide grep confirms zero remaining `process.env.ORIGIN` outside the new constant

## Follow-up Actions

- [ ] Add a focused unit test asserting `ORIGIN` trims whitespace and applies the fallback — nothing currently guards this exact fix from silently regressing (flagged by `/validate`).
- [ ] (Optional) Add `ORIGIN` to the zod env schema in `env.server.ts` for fail-fast validation at boot instead of a silent localhost fallback in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2baW9BoZgWbiWW1Jmyeg5